### PR TITLE
ADD Delete conversation history from working memory endpoint

### DIFF
--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -55,7 +55,7 @@ async def collection(request: Request, collection_id: str = "") -> Dict:
 
 
 # DELETE all collections
-@router.delete("/wipe_collections/")
+@router.delete("/wipe-collections/")
 async def wipe_collections(
     request: Request,
 ) -> Dict:
@@ -73,3 +73,17 @@ async def wipe_collections(
     ccat.load_memory()  # recreate the long term memories
 
     return to_return
+
+#DELETE conversation history from working memory
+@router.delete("/working-memory/conversation-history")
+async def wipe_conversation_history(
+    request: Request,
+) -> Dict:
+    """Delete conversation history from working memory"""
+
+    ccat = request.app.state.ccat
+    ccat.working_memory["history"] = []
+
+    return {
+        "deleted": "true",
+    }

--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -75,7 +75,7 @@ async def wipe_collections(
     return to_return
 
 #DELETE conversation history from working memory
-@router.delete("/working-memory/conversation-history")
+@router.delete("/working-memory/conversation-history/")
 async def wipe_conversation_history(
     request: Request,
 ) -> Dict:


### PR DESCRIPTION
This PR add a new endpoint /working-memory/conversation-history that DELETE the conversation history from working memory

Also change the endpoint url /wipe_collections/ to /wipe-collections/ to standardize the endpoints with the dash as discussed in public call on discord channel.

This PR is related to this issue: https://github.com/cheshire-cat-ai/core/issues/172 and solve step 1 required by @pieroit 

