### PR TITLE
Avoid traceback on simple Websockets disconnect

### DIFF
--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -1,7 +1,7 @@
 import traceback
 import asyncio
 
-from fastapi import APIRouter, WebSocket
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from cat.log import log
 
 router = APIRouter()
@@ -37,7 +37,9 @@ async def websocket_endpoint(websocket: WebSocket):
 
     try:
         await asyncio.gather(receive_message(), check_notification())
-    except Exception as e:  # WebSocketDisconnect as e:
+    except WebSocketDisconnect:
+        log("WebSocket connection closed", "INFO")
+    except Exception as e:
         log(e, "ERROR")
         traceback.print_exc()
 


### PR DESCRIPTION
# Description

This avoids to pollute the terminal logs with a long traceback every time a browser window is closed or refreshed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


