### PR TITLE
Changes to set the core ready for the plot in Memory

### DIFF
--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -119,12 +119,14 @@ class VectorMemoryCollection(Qdrant):
             query_vector=embedding,
             query_filter=self._qdrant_filter_from_dict(metadata),
             with_payload=True,
+            with_vectors=True,
             limit=k,
         )
         return [
             (
                 self._document_from_scored_point(m, self.content_payload_key, self.metadata_payload_key),
                 m.score,
+                m.vector
             )
             for m in memories
         ]

--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -24,13 +24,17 @@ async def recall_memories_from_text(
     ccat = request.app.state.ccat
     vector_memory = ccat.memory.vectors
 
+    # Embed the query to plot it in the Memory page
+    query = ccat.embedder.embed_query(text)
+
     episodes = vector_memory.episodic.recall_memories_from_text(text=text, k=k)
     documents = vector_memory.declarative.recall_memories_from_text(text=text, k=k)
 
-    episodes = [dict(m[0]) | {"score": float(m[1])} for m in episodes]
-    documents = [dict(m[0]) | {"score": float(m[1])} for m in documents]
+    episodes = [dict(m[0]) | {"score": float(m[1])} | {"vector": m[2]} for m in episodes]
+    documents = [dict(m[0]) | {"score": float(m[1])} | {"vector": m[2]} for m in documents]
 
     return {
+        "query": query,
         "episodic": episodes,
         "declarative": documents,
     }


### PR DESCRIPTION
# Description

This PR prepares the core to add the t-SNE plots in the Memory page:
- I added a "query" key to the JSON sent with the `recall/` endpoint holding the embedding of the query;
- I set the semantic search in the vector memories to return the vectors too 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
