### PR TITLE
Closes #289 (using node+python image in Dockerfile)

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.10.11-slim-bullseye
+FROM nikolaik/python-nodejs:python3.11-nodejs20
 
 ### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
 RUN mkdir -p /app && mkdir -p /admin
@@ -11,22 +11,6 @@ COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py
 RUN apt-get -y update && apt-get install -y curl build-essential xz-utils libmagic-mgc libmagic1 mime-support && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-### INSTALL NODEJS ###
-RUN NODEARCH= && dpkgArch="$(dpkg --print-architecture)" &&\
-    case "${dpkgArch##*-}" in \
-      amd64) NODEARCH='x64';; \
-      ppc64el) NODEARCH='ppc64le';; \
-      s390x) NODEARCH='s390x';; \
-      arm64) NODEARCH='arm64';; \
-      armhf) NODEARCH='armv7l';; \
-      i386) NODEARCH='x86';; \
-      *) echo "unsupported architecture"; exit 1 ;;\
-    esac &&\
-    curl -fsSLO --compressed "https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-${NODEARCH}.tar.xz" &&\
-    tar -xJf node-v18.16.0-linux-${NODEARCH}.tar.xz -C /usr/local --strip-components=1 --no-same-owner &&\
-    rm node-v18.16.0-linux-${NODEARCH}.tar.xz &&\
-    ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ### ADMIN (static build) ###
 WORKDIR /admin

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM nikolaik/python-nodejs:python3.11-nodejs20
+FROM nikolaik/python-nodejs:python3.10-nodejs18-slim
 
 ### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
 RUN mkdir -p /app && mkdir -p /admin


### PR DESCRIPTION
minor change to use docker image already containing node instead of installing it.