### PR TITLE
added `before_agent_creates_prompt` hook

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -31,6 +31,9 @@ class AgentManager:
             "agent_scratchpad",
         ]
 
+        input_variables = mad_hatter.execute_hook("before_agent_creates_prompt", input_variables,
+                                                  " ".join([prompt_prefix, prompt_format_instructions, prompt_suffix]))
+
         allowed_tools = mad_hatter.execute_hook("agent_allowed_tools", copy(mad_hatter.tools))
         allowed_tools_names = [t.name for t in allowed_tools]
 

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -36,3 +36,28 @@ def agent_allowed_tools(tools: List[BaseTool], cat) -> List[BaseTool]:
     allowed_tools = tools + default_tools
 
     return allowed_tools
+
+
+@hook(priority=0)
+def before_agent_creates_prompt(input_variables, main_prompt, cat):
+    """Hook to dynamically define the input variables.
+
+    Allows to dynamically filter the input variables that end up in the main prompt by looking for which placeholders
+    there are in it starting from a fixed list.
+
+    Args:
+        input_variables: list of placeholders to look for in the main prompt
+        main_prompt: string made of the prompt prefix, the agent instructions and the prompt suffix
+        cat: Cheshire Cat instance
+
+    Returns:
+        list of placeholders present in the main prompt.
+
+    """
+
+    # Loop the input variables and check if they are in the main prompt
+    input_variables = [i for i in input_variables if i in main_prompt]
+
+    return input_variables
+
+


### PR DESCRIPTION
# Description

I added an hook to dynamically define the input variables in the main prompt according to the placeholders present in there, otherwise removing those from the prompt would raise an error.

Related to issue #288

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
