### PR TITLE
Pre-install punkt (needed for RabbitHole)

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -38,6 +38,7 @@ RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/archive/main.tar.gz | 
 WORKDIR /app
 RUN pip install -U pip && \
     pip install --no-cache-dir ./ &&\
+    python3 -c "import nltk; nltk.download('punkt')" &&\
     python3 install_plugin_dependencies.py
 
 


### PR DESCRIPTION
# Description

Install `punkt` when building the container.

This is downloaded at runtime with nltk when using the Unstructured file loader in the RabbitHole. On Kubernetes it is blocking for me because I dont run the cat as the root user.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

