### PR TITLE
Fix loop on empty file upload

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
@@ -135,9 +135,13 @@ def rabbithole_summarizes_documents(docs: List[Document], cat) -> List[Document]
         cat: Cheshire Cat instance.
 
     Returns:
-        list of langchain`Document` with text summaries of the original ones.
+        list of langchain `Document` with text summaries of the original ones.
 
     """
+
+    if not docs:
+        return []
+
     # service variable to store intermediate results
     intermediate_summaries = docs
 


### PR DESCRIPTION
## Description

This pull request fixes the bug described in issue #292. The issue occurred when uploading a PDF file containing only images, resulting in an endless loop during summary creation. This pull request addresses the issue by adding a check for empty documents and returning an empty list when no documents are present.

Additionally, I would be happy to discuss [this line of code](https://github.com/cheshire-cat-ai/core/blob/main/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py#L93). I would remove it to allow even short documents to be processed by the summarizer hook. Would you have any thoughts to share about it?

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
