### PR TITLE
Added new endpoints, updated plugin metadata

### DIFF
--- a/core/cat/mad_hatter/core_plugin/plugin.json
+++ b/core/cat/mad_hatter/core_plugin/plugin.json
@@ -1,4 +1,10 @@
 {
-    "name": "Core CCat plugin",
-    "description": "The core Cat plugin used to define default hooks and tools. You don't see this plugin in the plugins folder, because it is an hidden plugin. It will be used to try out hooks and tools before they become available to other plugins. Written and delivered just for you, my furry friend."
+    "name": "Core CCat",
+    "description": "The core Cat plugin used to define default hooks and tools. You don't see this plugin in the plugins folder, because it is an hidden plugin. It will be used to try out hooks and tools before they become available to other plugins. Written and delivered just for you, my furry friend.",
+    "author_name": "Cheshire Cat",
+    "author_url": "https://github.com/cheshire-cat-ai",
+    "plugin_url": "https://github.com/cheshire-cat-ai/core",
+    "tags": "core, default, cat",
+    "thumb": "",
+    "version": "0.0.1"
 }

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -154,6 +154,12 @@ class MadHatter:
 
                 meta["name"] = json_file_data["name"]
                 meta["description"] = json_file_data["description"]
+                meta["author_name"] = json_file_data["author_name"]
+                meta["author_url"] = json_file_data["author_url"]
+                meta["plugin_url"] = json_file_data["plugin_url"]
+                meta["tags"] = json_file_data["tags"]
+                meta["thumb"] = json_file_data["thumb"]
+                meta["version"] = json_file_data["version"]
 
                 json_file.close()
 
@@ -167,6 +173,12 @@ class MadHatter:
             f"Please create a `{plugin_json_metadata_file_name}`"
             " in the plugin folder."
         )
+        meta["author_name"] = "Unknown author"
+        meta["author_url"] = ""
+        meta["plugin_url"] = ""
+        meta["tags"] = "unknown"
+        meta["thumb"] = ""
+        meta["version"] = "0.0.1"
 
         return meta
 

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -1,4 +1,4 @@
-from fastapi import Request, APIRouter, HTTPException
+from fastapi import Request, APIRouter, HTTPException, UploadFile, BackgroundTasks
 from typing import Dict
 
 router = APIRouter()
@@ -15,14 +15,32 @@ async def list_available_plugins(request: Request) -> Dict:
     # plugins are managed by the MadHatter class a = b if b else val
     plugins = ccat.mad_hatter.plugins or []
 
+    # retrieve plugins from official repo
+    registry = []
+
     return {
         "status": "success", 
-        "results": len(plugins), 
-        "plugins": plugins
+        "results": len(plugins) + len(registry), 
+        "installed": plugins,
+        "registry": registry
     }
 
 
-@router.get("/toggle/{plugin_id}", status_code=200)
+@router.post("/install/")
+async def install_plugin(
+    request: Request,
+    file: UploadFile,
+    background_tasks: BackgroundTasks
+) -> Dict:
+    """Install a new plugin from a zip file"""
+
+    # access cat instance
+    ccat = request.app.state.ccat
+
+    return {"error": "to be implemented"}
+
+
+@router.put("/toggle/{plugin_id}", status_code=200)
 async def toggle_plugin(plugin_id: str, request: Request) -> Dict:
     """Enable or disable a single plugin"""
 

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -12,7 +12,7 @@ router = APIRouter()
 # receive files via http endpoint
 # TODO: should we receive files also via websocket?
 @router.post("/")
-async def rabbithole_upload_endpoint(
+async def rabbithole_file_upload(
     request: Request,
     file: UploadFile,
     background_tasks: BackgroundTasks,
@@ -57,7 +57,7 @@ async def rabbithole_upload_endpoint(
 
 
 @router.post("/web/")
-async def rabbithole_url_endpoint(
+async def rabbithole_url_upload(
     request: Request,
     background_tasks: BackgroundTasks,
     url: str = Body(
@@ -88,3 +88,17 @@ async def rabbithole_url_endpoint(
             return {"url": url, "info": "Invalid URL"}
     except requests.exceptions.RequestException as e:
         return {"url": url, "info": "Unable to reach the link."}
+
+
+@router.post("/memory/")
+async def rabbithole_memory_upload(
+    request: Request,
+    file: UploadFile,
+    background_tasks: BackgroundTasks
+) -> Dict:
+    """Upload a memory json file to the CCat memory"""
+
+    # access cat instance
+    ccat = request.app.state.ccat
+
+    return {"error": "to be implemented"}


### PR DESCRIPTION
# Description

I added 2 new template endpoints:
`POST /plugins/install` -> to upload a zip containing the plugin files
`POST /rabbithole/memory` -> to upload a memory json file to give to the ccat's memory

I added new entries to the metadata of the plugins, adding default values and also updating the core plugin.json

Related to issue #300 and #287 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
