### PR TITLE
Add memory threshold to filter items

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -145,6 +145,14 @@ def after_cat_recalled_memories(memory_query_text: str, cat) -> None:
         memory_query_text: string used to query both *episodic* and *declarative* memories.
         cat: Cheshire Cat instance.
     """
+    #set the treshold to filter the memory items (items under threshold are removed from memory and not inserted in prompt)
+    threshold=0.8
+    for m in cat.working_memory["declarative_memories"][:]:
+        if (float(m[1]) < threshold):
+            cat.working_memory["declarative_memories"].remove(m)
+    for m in cat.working_memory["episodic_memories"][:]:
+        if (float(m[1]) < threshold):
+            cat.working_memory["episodic_memories"].remove(m)
     return None
 
 


### PR DESCRIPTION
# Description

This PR add a threshold value to the hook after_cat_recalled_memories to "filter" memory items. The items that not have a "score" (cosine similarity) equal or grater are removed from episodic and decalrative memory to have a context in the prompt "closest" to the user input.
The default value of threshold is 0.8 because after multiple test is the best value i have found. The threshold can be overrided in a hook with highest priority.

Related to issue #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
