### PR TITLE
Switch episodic/declarative collections on/off 

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -94,7 +94,7 @@ class CheshireCat:
         # Load plugin system
         self.mad_hatter = MadHatter(self)
 
-    def recall_relevant_memories_to_working_memory(self, user_message):
+    def recall_relevant_memories_to_working_memory(self, user_message, prompt_settings):
         # hook to do something before recall begins
         self.mad_hatter.execute_hook("before_cat_recalls_memories", user_message)
 
@@ -106,16 +106,30 @@ class CheshireCat:
         memory_query_embedding = self.embedder.embed_query(memory_query_text)
         self.working_memory["memory_query"] = memory_query_text
 
-        # recall relevant memories (episodic)
-        episodic_memories = self.memory.vectors.episodic.recall_memories_from_embedding(
-            embedding=memory_query_embedding
-        )
+        if "use_episodic_memory" in prompt_settings:
+            use_episodic = prompt_settings["use_episodic_memory"]
+
+        if (use_episodic == True):
+            # recall relevant memories (episodic)
+            episodic_memories = self.memory.vectors.episodic.recall_memories_from_embedding(
+                embedding=memory_query_embedding
+            )
+        else:
+            episodic_memories = []
+
         self.working_memory["episodic_memories"] = episodic_memories
 
-        # recall relevant memories (declarative)
-        declarative_memories = self.memory.vectors.declarative.recall_memories_from_embedding(
-            embedding=memory_query_embedding
-        )
+        if "use_declarative_memory" in prompt_settings:
+            use_declarative = prompt_settings["use_declarative_memory"]
+
+        if (use_declarative == True):
+            # recall relevant memories (declarative)
+            declarative_memories = self.memory.vectors.declarative.recall_memories_from_embedding(
+                embedding=memory_query_embedding
+            )
+        else:
+            declarative_memories = []
+
         self.working_memory["declarative_memories"] = declarative_memories
 
         # hook to modify/enrich retrieved memories
@@ -157,10 +171,16 @@ class CheshireCat:
         # extract actual user message text
         user_message = user_message_json["text"]
 
+        # check if user message contains prompt settings key and assign to prompt_settings variabkle
+        if "prompt_settings" in user_message_json:
+            prompt_settings = user_message_json["prompt_settings"]
+        else:
+            prompt_settings = None
+
         # recall episodic and declarative memories from vector collections
         #   and store them in working_memory
         try:
-            self.recall_relevant_memories_to_working_memory(user_message)
+            self.recall_relevant_memories_to_working_memory(user_message,prompt_settings)
         except Exception as e:
             log(e)
             traceback.print_exc(e)

--- a/core/cat/mad_hatter/core_plugin/hooks/prompt.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/prompt.py
@@ -114,9 +114,9 @@ def agent_prompt_suffix(cat) -> str:
     """
     suffix = """# Context
     
-## Context of things the Human said in the past:{episodic_memory}
+{episodic_memory}
 
-## Context of documents containing relevant information:{declarative_memory}
+{declarative_memory}
 
 ## Conversation until now:{chat_history}
  - Human: {input}
@@ -173,7 +173,11 @@ def agent_prompt_episodic_memories(memory_docs: List[Document], cat) -> str:
 
     # Format the memories for the output
     memories_separator = "\n  - "
-    memory_content = memories_separator + memories_separator.join(memory_texts)
+    memory_content = "## Context of things the Human said in the past: " + memories_separator + memories_separator.join(memory_texts)
+
+    #if no data is retrieved from memory don't erite anithing in the prompt
+    if len(memory_texts) == 0:
+        memory_content = ""
 
     return memory_content
 
@@ -220,7 +224,12 @@ def agent_prompt_declarative_memories(memory_docs: List[Document], cat) -> str:
 
     # Format the memories for the output
     memories_separator = "\n  - "
-    memory_content = memories_separator + memories_separator.join(memory_texts)
+    
+    memory_content = "## Context of documents containing relevant information: " + memories_separator + memories_separator.join(memory_texts)
+
+    # if no data is retrieved from memory don't erite anithing in the prompt
+    if len(memory_texts) == 0:
+        memory_content=""
 
     return memory_content
 


### PR DESCRIPTION
# Description

This PR add in the core the support for prompt_settings data send by the admin gui. If in the admin GUI the user switch off  the settings "Use Episodic Memory" or "Use Declarative Memory" setting the relative section on the prompt is not printed. 
IMPORTANT: Also if the user have switched on the "Use Episodic Memory" or "Use Declarative Memory" setting, on the prompt the relative section in some cases not printed out. This is because now the cat has a function to filter memory items under a threshold, if all data retrieved from memory are under the threshold the relative section in the prompt is not printed (this permit to have a short prompt without not relevant informations)

Related to issue [[#(issue)](https://github.com/cheshire-cat-ai/core/issues/306)](https://github.com/cheshire-cat-ai/core/issues/306)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

