### PR TITLE
add support for k an threshold parameter in qdrant

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -96,7 +96,7 @@ class CheshireCat:
 
     def recall_relevant_memories_to_working_memory(self, user_message):
         # hook to do something before recall begins
-        self.mad_hatter.execute_hook("before_cat_recalls_memories", user_message)
+        k, threshold = self.mad_hatter.execute_hook("before_cat_recalls_memories", user_message)
 
         # We may want to search in memory
         memory_query_text = self.mad_hatter.execute_hook("cat_recall_query", user_message)
@@ -108,13 +108,13 @@ class CheshireCat:
 
         # recall relevant memories (episodic)
         episodic_memories = self.memory.vectors.episodic.recall_memories_from_embedding(
-            embedding=memory_query_embedding
+            embedding=memory_query_embedding,k=k,threshold=threshold
         )
         self.working_memory["episodic_memories"] = episodic_memories
 
         # recall relevant memories (declarative)
         declarative_memories = self.memory.vectors.declarative.recall_memories_from_embedding(
-            embedding=memory_query_embedding
+            embedding=memory_query_embedding,k=k,threshold=threshold
         )
         self.working_memory["declarative_memories"] = declarative_memories
 

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -91,11 +91,16 @@ def before_cat_recalls_memories(user_message: str, cat) -> None:
     The hook is executed just before the Cat searches for the meaningful context in both memories
     and stores it in the *Working Memory*.
 
+    The hook return the values for maximum number (k) of item to retrieve from memory and the score threshold applied 
+    to the query in vector memory (items with score under threshold not are retreived)
+
     Args:
         user_message: string with the text received from the user. This is used as a query to search into memories.
         cat: Cheshire Cat instance.
     """
-    return None
+    k=3
+    threshold=0.8
+    return k,threshold
 
 
 # What is the input to recall memories?
@@ -145,15 +150,6 @@ def after_cat_recalled_memories(memory_query_text: str, cat) -> None:
         memory_query_text: string used to query both *episodic* and *declarative* memories.
         cat: Cheshire Cat instance.
     """
-    #set the treshold to filter the memory items (items under threshold are removed from memory and not inserted in prompt)
-    # TODO: check out the `score_threshold` in Qdrant search
-    threshold=0.8
-    for m in cat.working_memory["declarative_memories"][:]:
-        if (float(m[1]) < threshold):
-            cat.working_memory["declarative_memories"].remove(m)
-    for m in cat.working_memory["episodic_memories"][:]:
-        if (float(m[1]) < threshold):
-            cat.working_memory["episodic_memories"].remove(m)
     return None
 
 

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -131,7 +131,7 @@ class VectorMemoryCollection(Qdrant):
         return self.recall_memories_from_embedding(query_embedding, metadata=metadata, k=k)
 
     # retrieve similar memories from embedding
-    def recall_memories_from_embedding(self, embedding, metadata=None, k=3):
+    def recall_memories_from_embedding(self, embedding, metadata=None, k=3, threshold=0.8):
         # retrieve memories
         memories = self.client.search(
             collection_name=self.collection_name,
@@ -140,8 +140,7 @@ class VectorMemoryCollection(Qdrant):
             with_payload=True,
             with_vectors=True,
             limit=k,
-            #score_threshold=0.7 # at the moment we deal with min score in the hook `after_cat_recalled_memories`
-            #   this parameter at the moment is buggy and conflicts with `limit` 
+            score_threshold=threshold,
             search_params=SearchParams(
                 quantization=QuantizationSearchParams(
                     ignore=False,

--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -36,7 +36,7 @@ async def recall_memories_from_text(
     collections = list(vector_memory.collections.keys())
     recalled = {}
     for c in collections:
-        memories = vector_memory.collections[c].recall_memories_from_embedding(query_embedding, k=k)
+        memories = vector_memory.collections[c].recall_memories_from_embedding(query_embedding, k=k, threshold=0)
         recalled[c] = [dict(m[0]) | {"score": float(m[1])} | {"vector": m[2]} for m in memories]
     
     return {


### PR DESCRIPTION
# Description

This PR add the ability to set two parameters of qdrant query:
k= maximun items retrieved from memory (default 3)
threshold= minimum score that an item in memory needs to have to get retrived from qdrant query (default 0.8)

The ability to change this values is made by the hook before_cat_recalls_memories

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
