### PR TITLE
Support from new prompt settings

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -4,7 +4,7 @@ from copy import copy
 from cat.log import log
 from langchain.agents import AgentExecutor, ConversationalAgent
 from langchain.chains import LLMChain
-
+import re
 
 class AgentManager:
     """Manager of Langchain Agent.
@@ -67,6 +67,9 @@ class AgentManager:
             human_prefix="Human",
             input_variables=input_variables,
         )
+
+        # remove multiple empty lines from prompt
+        prompt.template = re.sub(r'\n\s*\n', '\n\n', prompt.template)
 
         log("Sending prompt", "INFO")
         log(prompt.template, "DEBUG")

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -148,7 +148,7 @@ class CheshireCat:
 
         # set the default prompt settings
         self.default_prompt_settings = {
-            "prefix": self.mad_hatter.execute_hook("agent_prompt_prefix"),
+            "prefix": "",
             "use_episodic_memory": True,
             "use_declarative_memory": True,
             "use_procedural_memory": True,

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -38,17 +38,23 @@ def agent_allowed_tools(cat) -> List[BaseTool]:
     # Embed the user's input to query the procedural memory with it
     query_embedding = cat.embedder.embed_query(user_input)
 
-    # Make semantic search in the procedural memory to retrieve the name of the most suitable tools
-    embedded_tools = cat.memory.vectors.procedural.recall_memories_from_embedding(
-        query_embedding, k=5, threshold=0.6
-    )
+    # Check if procedural memory is enabled
+    prompt_settings = cat.working_memory["user_message_json"]["prompt_settings"]
 
-    # Get the tools names only
-    tools_names = [t[0].metadata["name"] for t in embedded_tools]
+    if prompt_settings["use_procedural_memory"]:
+        # Make semantic search in the procedural memory to retrieve the name of the most suitable tools
+        embedded_tools = cat.memory.vectors.procedural.recall_memories_from_embedding(
+            query_embedding, k=5, threshold=0.6
+        )
+        # Get the tools names only
+        tools_names = [t[0].metadata["name"] for t in embedded_tools]
 
-    # Get the LangChain BaseTool by name
-    tools = [i for i in cat.mad_hatter.tools if i.name in tools_names]
+        # Get the LangChain BaseTool by name
+        tools = [i for i in cat.mad_hatter.tools if i.name in tools_names]
 
+    else:
+        tools=[]
+    
     # log(tools, "ERROR")
 
     # Add LangChain default tools

--- a/core/cat/mad_hatter/core_plugin/hooks/prompt.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/prompt.py
@@ -35,6 +35,7 @@ def agent_prompt_prefix(cat) -> str:
     Notes
     -----
     The default prefix describe who the AI is and how it is expected to answer the Human.
+    With prompt_settings sent in the json you can change the prefix.
     The next part of the prompt (generated form the *Agent*) contains the list of available Tools.
 
     """
@@ -42,6 +43,12 @@ def agent_prompt_prefix(cat) -> str:
 You are curious, funny and talk like the Cheshire Cat from Alice's adventures in wonderland.
 You answer Human using tools and context.
 """
+
+    # check if custom prompt is sent in prompt settings
+    prompt_settings = cat.working_memory["user_message_json"]["prompt_settings"]
+
+    if prompt_settings["prefix"]:
+        prefix = prompt_settings["prefix"]
 
     return prefix
 
@@ -96,6 +103,12 @@ Thought: Do I need to use a tool? No
 {ai_prefix}: [your response here]
 ```"""
 
+    # Check if procedural memory is enabled
+    prompt_settings = cat.working_memory["user_message_json"]["prompt_settings"]
+
+    if prompt_settings["use_procedural_memory"]==False:
+        instructions=""
+
     return instructions
 
 
@@ -128,8 +141,8 @@ def agent_prompt_suffix(cat) -> str:
     - {agent_scratchpad} is where the *Agent* can concatenate tools use and multiple calls to the LLM.
 
     """
-    suffix = """# Context
-    
+    suffix = """# Context:
+
 {episodic_memory}
 
 {declarative_memory}

--- a/core/cat/mad_hatter/core_plugin/hooks/prompt.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/prompt.py
@@ -127,7 +127,7 @@ def agent_prompt_suffix(cat) -> str:
 
     """
     suffix = """# Context
-    
+
 {episodic_memory}
 
 {declarative_memory}


### PR DESCRIPTION
# Description

This PR add core support for 2 new prompt settings available in admin GUI:

Prompt prefix
Use procedural memory (=tools)
I have also introduced a regular expression that purge propmt when there are multiples empty new lines, this permit to have short prompt and read better the log.

To do this PR works i have changed in cheshire_cat.py line 151 the default prompt prefix value from:

"prefix": self.mad_hatter.execute_hook("agent_prompt_prefix"),
to:
"prefix": "",

Because the new feature need to have access to working memory that it not already initialized when default prompt settings are declared. This change has no impact on normal operations of the cat.

UPDATED with new hook agent instruction definition

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
