### PR TITLE
add feature: k and t for every memory

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -192,7 +192,8 @@ class CheshireCat:
         prompt_settings = self.working_memory["user_message_json"]["prompt_settings"]
 
         # hook to do something before recall begins
-        k, threshold = self.mad_hatter.execute_hook("before_cat_recalls_memories", user_message)
+        k_episodic, threshold_episodic, k_decalrative, threshold_decalrative, k_procedural, threshold_procedural = self.mad_hatter.execute_hook(
+            "before_cat_recalls_memories", user_message)
 
         # We may want to search in memory
         memory_query_text = self.mad_hatter.execute_hook("cat_recall_query", user_message)
@@ -207,8 +208,8 @@ class CheshireCat:
             # recall relevant memories (episodic)
             episodic_memories = self.memory.vectors.episodic.recall_memories_from_embedding(
                 embedding=memory_query_embedding,
-                k=k,
-                threshold=threshold,
+                k=k_episodic,
+                threshold=threshold_episodic,
                 metadata={
                     "source": user_id
                 }
@@ -222,7 +223,7 @@ class CheshireCat:
         if prompt_settings["use_declarative_memory"]:
             # recall relevant memories (declarative)
             declarative_memories = self.memory.vectors.declarative.recall_memories_from_embedding(
-                embedding=memory_query_embedding, k=k, threshold=threshold
+                embedding=memory_query_embedding, k=k_decalrative, threshold=threshold_decalrative
             )
         else:
             declarative_memories = []
@@ -233,7 +234,7 @@ class CheshireCat:
         if prompt_settings["use_procedural_memory"]:
             # recall relevant tools (procedural collection)
             tools = self.memory.vectors.procedural.recall_memories_from_embedding(
-                embedding=memory_query_embedding, k=k, threshold=threshold
+                embedding=memory_query_embedding, k=k_procedural, threshold=threshold_procedural
             )
         else:
             tools = []

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -115,14 +115,18 @@ def before_cat_recalls_memories(user_message: str, cat) -> tuple[int, float]:
 
     Returns
     -------
-    k : int
+    k_memory_type : int
         Number of relevant memories to retrieve from the vector database.
-    threshold : float
+    threshold_memory_type : float
         Threshold to filter memories according their similarity score with the query.
     """
-    k = 3
-    threshold = 0.7
-    return k, threshold
+    k_episodic = 3
+    threshold_episodic = 0.7
+    k_decalrative = 3
+    threshold_decalrative = 0.7
+    k_procedural = 3
+    threshold_procedural = 0.7
+    return k_episodic, threshold_episodic, k_decalrative, threshold_decalrative, k_procedural, threshold_procedural
 
 
 # Called just before the cat recalls memories.


### PR DESCRIPTION
# Description

This PR add the k and threshold parameters for every single memory (episodic, declarative, procedural). Now it's possibile  to set different k and t values for single memory type. This PR change the before_cat_recalls_memories default hook adding more output parameters

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
