### PR TITLE
Fix regression in OpenAIEmbeddings coming from LangChain upgrade

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -45,8 +45,8 @@ class EmbedderAzureOpenAIConfig(EmbedderSettings):
     openai_api_key: str
     model: str
     openai_api_base: str
-    api_type: str
-    api_version: str
+    openai_api_type: str
+    openai_api_version: str
     deployment: str
 
     _pyclass: PyObject = langchain.embeddings.OpenAIEmbeddings


### PR DESCRIPTION
langchain relevant commits are:
https://github.com/hwchase17/langchain/commit/a48810fb21fca475e7d0e820a16dae0ce2db56a3 https://github.com/hwchase17/langchain/commit/3954bcf396389ccd042b5fa469bedad792596024

when we bumped the langchain version this regression was introduced:

```
  File "/usr/local/lib/python3.10/site-packages/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 2 validation errors for OpenAIEmbeddings
api_type
  extra fields not permitted (type=value_error.extra)
api_version
  extra fields not permitted (type=value_error.extra)
```
**This is a breaking change, the users will have to delete the database configuration and start with a new db.**

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


