### PR TITLE
Summarization is deactivated by default

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
@@ -190,5 +190,4 @@ def rabbithole_summarizes_documents(docs: List[Document], cat) -> List[Document]
         # add summary to list of all summaries
         all_summaries.append(summary)
 
-    print(all_summaries)
     return all_summaries

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -27,6 +27,7 @@ class RabbitHole:
         file: Union[str, UploadFile],
         chunk_size: int = 400,
         chunk_overlap: int = 100,
+        summary: bool = False,
     ):
         """Load a file in the Cat's declarative memory.
 
@@ -58,11 +59,12 @@ class RabbitHole:
             file=file, chunk_size=chunk_size, chunk_overlap=chunk_overlap
         )
 
-        # get summaries
-        summaries = self.cat.mad_hatter.execute_hook(
-            "rabbithole_summarizes_documents", docs
-        )
-        docs = summaries + docs
+        # get summaries if summarization is requested
+        if summary:
+            summaries = self.cat.mad_hatter.execute_hook(
+                "rabbithole_summarizes_documents", docs
+            )
+            docs = summaries + docs
 
         # store in memory
         if isinstance(file, str):
@@ -76,6 +78,7 @@ class RabbitHole:
         url: str,
         chunk_size: int = 400,
         chunk_overlap: int = 100,
+        summary: bool = False,
     ):
         """Load a webpage in the Cat's declarative memory.
 
@@ -103,11 +106,12 @@ class RabbitHole:
             url=url, chunk_size=chunk_size, chunk_overlap=chunk_overlap
         )
 
-        # get summaries
-        summaries = self.cat.mad_hatter.execute_hook(
-            "rabbithole_summarizes_documents", docs
-        )
-        docs = summaries + docs
+        # get summaries if summarization requested
+        if summary:
+            summaries = self.cat.mad_hatter.execute_hook(
+                "rabbithole_summarizes_documents", docs
+            )
+            docs = summaries + docs
 
         # store docs in memory
         self.store_documents(docs=docs, source=url)

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -21,6 +21,7 @@ async def upload_file(
         description="Maximum length of each chunk after the document is split (in characters)",
     ),
     chunk_overlap: int = Body(default=100, description="Chunk overlap (in characters)"),
+    summary: bool = Body(default=False, description="Enables call to summary hook for this file")
 ) -> Dict:
     """Upload a file containing text (.txt, .md, .pdf, etc.). File content will be extracted and segmented into chunks.
     Chunks will be then vectorized and stored into documents memory.
@@ -45,7 +46,7 @@ async def upload_file(
 
     # upload file to long term memory, in the background
     background_tasks.add_task(
-        ccat.rabbit_hole.ingest_file, file, chunk_size, chunk_overlap
+        ccat.rabbit_hole.ingest_file, file, chunk_size, chunk_overlap, summary
     )
 
     # reply to client
@@ -68,6 +69,7 @@ async def upload_url(
         description="Maximum length of each chunk after the document is split (in characters)",
     ),
     chunk_overlap: int = Body(default=100, description="Chunk overlap (in characters)"),
+    summary: bool = Body(default=False, description="Enables call to summary hook for this website")
 ):
     """Upload a url. Website content will be extracted and segmented into chunks.
     Chunks will be then vectorized and stored into documents memory."""
@@ -83,7 +85,7 @@ async def upload_url(
 
             # upload file to long term memory, in the background
             background_tasks.add_task(
-                ccat.rabbit_hole.ingest_url, url, chunk_size, chunk_overlap
+                ccat.rabbit_hole.ingest_url, url, chunk_size, chunk_overlap, summary
             )
             return {"url": url, "info": "Website is being ingested asynchronously"}
         else:


### PR DESCRIPTION
# Description

Endpoints upload_file and upload_url accept now a boolean `summary` default False.
Summarization is deactivated by default, plus default summarization isn't hierarchical anymore, is a simple one-level grouped summarization. 

Related to issue #342

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
