### PR TITLE
Added support for other mimetypes in plugin upload

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -8,7 +8,7 @@ from cat.log import log
 from cat.db.database import get_db_session, create_db_and_tables
 from cat.rabbit_hole import RabbitHole
 from cat.mad_hatter.mad_hatter import MadHatter
-from cat.memory.working_memory import WorkingMemory, WorkingMemoryList
+from cat.memory.working_memory import WorkingMemoryList
 from cat.memory.long_term_memory import LongTermMemory
 from cat.looking_glass.agent_manager import AgentManager
 
@@ -124,7 +124,7 @@ class CheshireCat:
         hypothetical_embedding_prompt
         summarization_prompt
         agent_prompt_prefix
-         """
+        """
         # LLM and embedder
         self.llm = self.mad_hatter.execute_hook("get_language_model")
         self.embedder = self.mad_hatter.execute_hook("get_language_embedder")

--- a/core/cat/memory/long_term_memory.py
+++ b/core/cat/memory/long_term_memory.py
@@ -3,7 +3,7 @@ from cat.memory.vector_memory import VectorMemory
 
 # This class represents the Cat long term memory (content the cat saves on disk).
 class LongTermMemory:
-    """Cat's memory.
+    """Cat's non-volatile memory.
 
     This is an abstract class to interface with the Cat's vector memory collections.
 

--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -66,7 +66,7 @@ async def recall_memories_from_text(
             memory_dict["score"] = float(score)
             memory_dict["vector"] = vector
             recalled[c].append(memory_dict)
- 
+
     return {
         "status": "success",
         "query": query,

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -1,8 +1,7 @@
 from typing import Dict
-import tempfile
+from tempfile import NamedTemporaryFile
 import shutil
 from fastapi import Request, APIRouter, HTTPException, UploadFile
-from fastapi.responses import JSONResponse
 from cat.log import log
 
 
@@ -46,9 +45,9 @@ async def upload_plugin(
     # check if file has an accepted mime type
     log(f"Uploading {file.content_type} plugin {file.filename}", "INFO")
     if file.content_type not in accepted_mime_types:
-        return JSONResponse(
+        raise HTTPException(
             status_code=422,
-            content={
+            detail={
                 "error": f'MIME type `{file.content_type}` not supported. Please upload a file of type ' + 
                     f'({", ".join([mime for mime in accepted_mime_types])}).'
             },
@@ -56,7 +55,7 @@ async def upload_plugin(
     
     # Create temporary file (dunno how to extract from memory) #TODO: extract directly from memory
     file_bytes = file.file.read()
-    temp_file = tempfile.NamedTemporaryFile(dir="/tmp/", delete=False)
+    temp_file = NamedTemporaryFile(dir="/tmp/", delete=False)
     temp_name = temp_file.name
     with open(temp_name, "wb") as temp_binary_file:
         # Write bytes to file

--- a/core/cat/routes/setting/prompt_setting.py
+++ b/core/cat/routes/setting/prompt_setting.py
@@ -1,6 +1,4 @@
 from fastapi import APIRouter, Request
-from sqlalchemy.orm import Session
-from cat.db.database import get_db_session
 
 router = APIRouter()
 


### PR DESCRIPTION
# Description

I added support for .tar files when uploading files via endpoint `/plugins/upload`. 
In this way it is also extendable in the future in case of support for other formats.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
