### PR TITLE
Qdrant local storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 **/node_modules
 **/npm-debug.log
 **/qdrant
-**/long_term_memory
+**/local_vector_memory

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 CORE_HOST=localhost
 CORE_PORT=1865
 
+# Qdrant server
+# QDRANT_HOST=localhost
+# QDRANT_PORT=6333
+
 # Decide to use https / wss secure protocols
 #CORE_USE_SECURE_PROTOCOLS=true
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ core/venv
 .vscode
 
 # DBs
-long_term_memory
+/core/local_vector_memory
 *metadata.db
 *metadata-v*.db
 test_db.db

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -81,18 +81,15 @@ class MadHatter:
     def embed_tools(self):
 
         # retrieve from vectorDB all tool embeddings
-        vector_db = self.ccat.memory.vectors.vector_db
-        all_tools_points, _ = vector_db.scroll(
-            collection_name="procedural",
-            with_vectors=True,
-            limit=None,
-        )
+        all_tools_points = self.ccat.memory.vectors.procedural.get_all_points()
 
         # easy access to plugin tools
         plugins_tools_index = {t.description: t for t in self.tools}
         #log(plugins_tools_index, "WARNING")
 
         points_to_be_deleted = []
+        
+        vector_db = self.ccat.memory.vectors.vector_db
 
         # loop over vectors
         for record in all_tools_points:

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -16,7 +16,7 @@ from qdrant_client.http.models import (Distance, VectorParams,  SearchParams,
 
 class VectorMemory:
 
-    vector_db = None
+    local_vector_db = None
 
     def __init__(self, cat, verbose=False) -> None:
         self.verbose = verbose
@@ -43,7 +43,7 @@ class VectorMemory:
             # Instantiate collection
             collection = VectorMemoryCollection(
                 cat=cat,
-                client=VectorMemory.vector_db,
+                client=self.vector_db,
                 collection_name=collection_name,
                 embeddings=self.embedder,
                 vector_size=self.embedder_size,
@@ -66,8 +66,10 @@ class VectorMemory:
             # Qdrant local vector DB client
             
             # reconnect only if it's the first boot and not a reload
-            if VectorMemory.vector_db is None:
-                VectorMemory.vector_db = QdrantClient(path=db_path)
+            if VectorMemory.local_vector_db is None:
+                VectorMemory.local_vector_db = QdrantClient(path=db_path)
+                
+            self.vector_db = VectorMemory.local_vector_db
         else:
             qdrant_port = int(os.getenv("QDRANT_PORT", 6333))
 

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -216,3 +216,24 @@ class VectorMemoryCollection(Qdrant):
         #    doc.lc_kwargs = None
 
         return langchain_documents_from_points
+
+    # retrieve all the points in the collection
+    def get_all_points(self):
+
+        # counting points in the collection
+        points_count = self.client.count(
+            collection_name=self.collection_name, 
+            exact=True
+        )
+        points_count = points_count.count
+
+        log(f"{self.collection_name} memory points: {points_count}","INFO")
+
+        # retrieving the points
+        all_points, _ = self.client.scroll(
+            collection_name=self.collection_name,
+            with_vectors=True,
+            limit= points_count
+        )
+
+        return all_points

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,12 @@ services:
     build:
       context: ./core
     container_name: cheshire_cat_core
-    depends_on:
-      - cheshire-cat-vector-memory
     environment:
       - PYTHONUNBUFFERED=1
       - CORE_HOST=${CORE_HOST:-localhost}
       - CORE_PORT=${CORE_PORT:-1865}
+      - QDRANT_HOST=${QDRANT_HOST:-}
+      - QDRANT_PORT=${QDRANT_PORT:-6333}
       - CORE_USE_SECURE_PROTOCOLS=${CORE_USE_SECURE_PROTOCOLS:-}
       - API_KEY=${API_KEY:-}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
@@ -32,13 +32,3 @@ services:
       - --reload-exclude
       - "tests/**/*.*"
     restart: unless-stopped
-
-  cheshire-cat-vector-memory:
-    image: qdrant/qdrant:v1.1.1
-    container_name: cheshire_cat_vector_memory
-    expose:
-      - 6333
-    volumes:
-      - ./long_term_memory/vector:/qdrant/storage
-    restart: unless-stopped
-


### PR DESCRIPTION
# Description

This PR adds the use of [qdrant local](https://github.com/qdrant/qdrant-client#local-mode) in the cat by default.

The qdrant docker container has been removed, to connect to an external qdrant server just set `QDRANT_HOST` and `QDRANT_PORT` in the .env file

Related to issue #308 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
