### PR TITLE
added optimization in vector memory

### DIFF
--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -9,7 +9,7 @@ from langchain.embeddings.base import Embeddings
 from langchain.vectorstores import Qdrant
 from qdrant_client.http.models import (Distance, VectorParams,  SearchParams, 
                                     ScalarQuantization, ScalarQuantizationConfig, ScalarType, QuantizationSearchParams, 
-                                    CreateAliasOperation, CreateAlias)
+                                    CreateAliasOperation, CreateAlias, OptimizersConfigDiff)
 
 
 class VectorMemory:
@@ -151,6 +151,7 @@ class VectorMemoryCollection(Qdrant):
             collection_name=self.collection_name,
             vectors_config=VectorParams(
                 size=self.embedder_size, distance=Distance.COSINE),
+            optimizers_config=OptimizersConfigDiff(memmap_threshold=20000),
             quantization_config=ScalarQuantization(
                 scalar=ScalarQuantizationConfig(
                     type=ScalarType.INT8,


### PR DESCRIPTION
# Description

Added 2 parameters in vector memory creation:

* memmap_threshold: Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing [based value 20000](https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md)
* shard_number: which defines how many shards the collection should have

Related to issue #47 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
