### PR TITLE
Make TinyDB filename configurable

### DIFF
--- a/core/cat/db/database.py
+++ b/core/cat/db/database.py
@@ -1,4 +1,5 @@
 from tinydb import TinyDB
+import os
 
 #TODO can we add a verbose level for logging?
 
@@ -11,11 +12,10 @@ class Database:
             cls._instance = super().__new__(cls)
             cls._instance.db = TinyDB(cls._instance.get_file_name())
         return cls._instance.db
-    
-    def get_file_name(self):
-        return "metadata.json"
-    
 
+    def get_file_name(self):
+        tinydb_file = os.getenv("METADATA_FILE", "metadata.json")
+        return tinydb_file
 
 def get_db():
     return Database()


### PR DESCRIPTION
# Description

I need this change  for running the cat on Kubernetes, passing this env variable to the Pod:

```
        - name: TINYDB_FILE
          value: "/app/core/database/tinydb.json"
```

this is because the `database` folder is mounted read write but the rest of the filesystem is readonly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

