### PR TITLE
Delete history on websocket disconnect

### DIFF
--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -10,6 +10,7 @@ router = APIRouter()
 class ConnectionManager:
     def __init__(self):
         self.active_connections: list[WebSocket] = []
+        self.ccat = None
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
@@ -17,6 +18,7 @@ class ConnectionManager:
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.remove(websocket)
+        self.ccat.working_memory["history"] = []
 
     async def send_personal_message(self, message: str, websocket: WebSocket):
         await websocket.send_json(message)
@@ -33,6 +35,7 @@ async def websocket_endpoint(websocket: WebSocket):
     ccat = websocket.app.state.ccat
 
     await manager.connect(websocket)
+    manager.ccat = ccat
 
     async def receive_message():
         while True:


### PR DESCRIPTION
# Description

The history is deleted from working memory on websocket disconnect

Related to issue #392 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
