### PR TITLE
No active in plugin

### DIFF
--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -71,21 +71,12 @@ class Plugin:
         return meta
         
     def activate(self):
-        self.active = True
         # lists of hooks and tools
         self.load_hooks_and_tools()
 
     def deactivate(self):
-        self.active = False
         self.hooks = []
         self.tools = []
-    
-    def toggle(self):
-
-        if self.active:
-            self.deactivate()
-        else:
-            self.activate()
 
     # get plugin settings JSON schema
     def get_settings_schema(self):
@@ -191,21 +182,8 @@ class Plugin:
     def is_cat_hook(self, obj):
         return isinstance(obj, CatHook)
 
-
     # a plugin tool function has to be decorated with @tool
     # (which returns an instance of CatTool)
     def is_cat_tool(self, obj):
         return isinstance(obj, CatTool)
-    
-
-
-
-
-
-
-
-
-
-
-
     

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -16,11 +16,13 @@ async def list_available_plugins(request: Request) -> Dict:
     # access cat instance
     ccat = request.app.state.ccat
 
+    active_plugins = ccat.mad_hatter.load_active_plugins_from_db()
+
     # plugins are managed by the MadHatter class
     plugins = []
     for p in ccat.mad_hatter.plugins.values():
         manifest = deepcopy(p.manifest) # we make a copy to avoid modifying the plugin obj
-        manifest["active"] = p.active # pass along if plugin is active or not
+        manifest["active"] = p.id in active_plugins # pass along if plugin is active or not
         plugins.append(manifest)
 
     # retrieve plugins from official repo
@@ -109,9 +111,11 @@ async def get_plugin_details(plugin_id: str, request: Request) -> Dict:
             detail = { "error": "Plugin not found" }
         )
 
+    active_plugins = ccat.mad_hatter.load_active_plugins_from_db()
+
     # get manifest and active True/False. We make a copy to avoid modifying the original obj
     plugin_info = deepcopy(ccat.mad_hatter.plugins[plugin_id].manifest)
-    plugin_info["active"] = ccat.mad_hatter.plugins[plugin_id].active
+    plugin_info["active"] = plugin_id in active_plugins
 
     return {
         "status": "success",

--- a/core/tests/mad_hatter/test_mad_hatter.py
+++ b/core/tests/mad_hatter/test_mad_hatter.py
@@ -29,7 +29,7 @@ def test_instantiation_discovery(mad_hatter):
     # Mad Hatter finds core_plugin
     assert list(mad_hatter.plugins.keys()) == ["core_plugin"]
     assert isinstance(mad_hatter.plugins["core_plugin"], Plugin)
-    assert mad_hatter.plugins["core_plugin"].active
+    assert "core_plugin" in mad_hatter.load_active_plugins_from_db()
 
     # finds hooks
     assert len(mad_hatter.hooks) > 0
@@ -73,7 +73,7 @@ def test_plugin_install(mad_hatter: MadHatter):
     # plugins list updated
     assert list(mad_hatter.plugins.keys()) == ["core_plugin", "mock_plugin"]
     assert isinstance(mad_hatter.plugins["mock_plugin"], Plugin)
-    assert mad_hatter.plugins["mock_plugin"].active # plugin starts active
+    assert "mock_plugin" in mad_hatter.load_active_plugins_from_db() # plugin starts active
 
     # plugin is activated by default
     assert len(mad_hatter.plugins["mock_plugin"].hooks) == 1


### PR DESCRIPTION
# Description

Removed from the Plugin class the attribute `active` and the method `toggle`.
Now to check if a plugin is active you have to check if it is present in the list returned by the MadHatter `load_active_plugins_from_db` method.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
