### PR TITLE
Match json schema casing

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -23,8 +23,8 @@ class EmbedderFakeConfig(EmbedderSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Default Embedder",
-            "description": "Configuration for default embedder. It just outputs random numbers XD",
+            "humanReadableName": "Default Embedder",
+            "description": "Configuration for default embedder. It just outputs random numbers.",
         }
 
 
@@ -35,7 +35,7 @@ class EmbedderOpenAIConfig(EmbedderSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "OpenAI Embedder",
+            "humanReadableName": "OpenAI Embedder",
             "description": "Configuration for OpenAI embeddings",
         }
 
@@ -53,7 +53,7 @@ class EmbedderAzureOpenAIConfig(EmbedderSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Azure OpenAI Embedder",
+            "humanReadableName": "Azure OpenAI Embedder",
             "description": "Configuration for Azure OpenAI embeddings",
         }
 
@@ -65,7 +65,7 @@ class EmbedderCohereConfig(EmbedderSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Cohere Embedder",
+            "humanReadableName": "Cohere Embedder",
             "description": "Configuration for Cohere embeddings",
         }
 
@@ -77,7 +77,7 @@ class EmbedderHuggingFaceHubConfig(EmbedderSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "HuggingFace Hub Embedder",
+            "humanReadableName": "HuggingFace Hub Embedder",
             "description": "Configuration for HuggingFace Hub embeddings",
         }
 

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -27,7 +27,7 @@ class LLMDefaultConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Default Language Model",
+            "humanReadableName": "Default Language Model",
             "description":
                 "A dumb LLM just telling that the Cat is not configured. "
                 "There will be a nice LLM here "
@@ -53,9 +53,10 @@ class LLMCustomConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Custom LLM",
-            "description": "LLM on a custom endpoint. "
-                           "see docs for examples.",
+            "humanReadableName": "Custom LLM",
+            "description": 
+                "LLM on a custom endpoint. "
+                "See docs for examples.",
         }
 
 
@@ -66,7 +67,7 @@ class LLMOpenAIChatConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "OpenAI ChatGPT",
+            "humanReadableName": "OpenAI ChatGPT",
             "description": "Chat model from OpenAI",
         }
 
@@ -78,9 +79,10 @@ class LLMOpenAIConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "OpenAI GPT-3",
-            "description": "OpenAI GPT-3. More expensive but "
-                           "also more flexible than ChatGPT.",
+            "humanReadableName": "OpenAI GPT-3",
+            "description": 
+                "OpenAI GPT-3. More expensive but "
+                "also more flexible than ChatGPT.",
         }
 
 
@@ -99,7 +101,7 @@ class LLMAzureChatOpenAIConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Azure OpenAI Chat Models",
+            "humanReadableName": "Azure OpenAI Chat Models",
             "description": "Chat model from Azure OpenAI",
         }
 
@@ -120,7 +122,7 @@ class LLMAzureOpenAIConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Azure OpenAI Completion models",
+            "humanReadableName": "Azure OpenAI Completion models",
             "description": "Configuration for Cognitive Services Azure OpenAI",
         }
 
@@ -132,7 +134,7 @@ class LLMCohereConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Cohere",
+            "humanReadableName": "Cohere",
             "description": "Configuration for Cohere language model",
         }
 
@@ -149,7 +151,7 @@ class LLMHuggingFaceTextGenInferenceConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "HuggingFace TextGen Inference",
+            "humanReadableName": "HuggingFace TextGen Inference",
             "description": "Configuration for HuggingFace TextGen Inference",
         }
 
@@ -165,7 +167,7 @@ class LLMHuggingFaceHubConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "HuggingFace Hub",
+            "humanReadableName": "HuggingFace Hub",
             "description": "Configuration for HuggingFace Hub language models",
         }
 
@@ -178,7 +180,7 @@ class LLMHuggingFaceEndpointConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "HuggingFace Endpoint",
+            "humanReadableName": "HuggingFace Endpoint",
             "description":
                 "Configuration for HuggingFace Endpoint language models",
         }
@@ -191,8 +193,8 @@ class LLMAnthropicConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Anthropic",
-            "description": "Configuration for Anthropic language Model",
+            "humanReadableName": "Anthropic",
+            "description": "Configuration for Anthropic language model",
         }
 
 
@@ -203,7 +205,7 @@ class LLMGooglePalmConfig(LLMSettings):
 
     class Config:
         schema_extra = {
-            "name_human_readable": "Google PaLM",
+            "humanReadableName": "Google PaLM",
             "description": "Configuration for Google PaLM language model",
         }
 


### PR DESCRIPTION
# Description

I fixed the text casing to match the camelCase of the json schema.
I also fixed some typos.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
