### PR TITLE
Really fixed the return direct

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -137,10 +137,19 @@ class AgentManager:
         #Adding the tools_output key in agent input, needed by the memory chain
         if tools_result != None:
             
-            # ((tool_name, tool_input), output)
+            # Extract of intermediate steps in the format ((tool_name, tool_input), output)
             used_tools = list(map(lambda x:((x[0].tool, x[0].tool_input), x[1]), tools_result["intermediate_steps"]))
 
-            if self.cat.mad_hatter.tools[0].return_direct:
+            # Get the name of the tools that have return_direct
+            return_direct_tools = []
+            for t in allowed_tools:
+                if t.return_direct:
+                    return_direct_tools.append(t.name)
+
+            # execute_tool_agent returns immediately when a tool with return_direct is called, 
+            # so if one is used it is definitely the last one used
+            if used_tools[-1][0][0] in return_direct_tools:
+                # intermediate_steps still contains the information of all the tools used even if their output is not returned
                 tools_result["intermediate_steps"] = used_tools
                 return tools_result
 


### PR DESCRIPTION
# Description

The return direct should be really fixed now, when a tool having `return_direct = True` is used the `execute_tool_agent` return immediately and the tool output is showed in chat.

If multiple tools are used, the `intermediate_steps` are still shown in the `why` but in the chat only the output of the tool with `return_direct` is shown.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
