### PR TITLE
Reduced MadHatter access to db

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -24,9 +24,14 @@ class MadHatter:
 
     def __init__(self, ccat):
         self.ccat = ccat
+
         self.plugins = {} # plugins dictionary
+
         self.hooks = [] # list of active plugins hooks 
         self.tools = [] # list of active plugins tools 
+
+        self.active_plugins = self.load_active_plugins_from_db()
+
         self.find_plugins()
 
     def install_plugin(self, package_plugin):
@@ -55,12 +60,10 @@ class MadHatter:
         
     def uninstall_plugin(self, plugin_id):
 
-        active_plugins = self.load_active_plugins_from_db()
-
         if self.plugin_exists(plugin_id):
 
             # deactivate plugin if it is active (will sync cache)
-            if plugin_id in active_plugins:
+            if plugin_id in self.active_plugins:
                 self.toggle_plugin(plugin_id)
 
             # remove plugin from cache
@@ -85,19 +88,16 @@ class MadHatter:
         plugins_folder = self.ccat.get_plugin_path()
 
         all_plugin_folders = [core_plugin_folder] + glob.glob(f"{plugins_folder}*/")
-        
-        # db contains the list of active plugins
-        active_plugins = self.load_active_plugins_from_db()
 
         log("ACTIVE PLUGINS:", "INFO")
-        log(active_plugins, "INFO")
+        log(self.active_plugins, "INFO")
 
         # discover plugins, folder by folder
         for folder in all_plugin_folders:
 
             # is the plugin active?
             folder_base = os.path.basename(os.path.normpath(folder))
-            is_active = folder_base in active_plugins
+            is_active = folder_base in self.active_plugins
 
             self.load_plugin(folder, is_active)
 
@@ -119,11 +119,9 @@ class MadHatter:
         self.hooks = []
         self.tools = []
 
-        active_plugins = self.load_active_plugins_from_db()
-
         for _, plugin in self.plugins.items():
             # load hooks and tools
-            if plugin.id in active_plugins:
+            if plugin.id in self.active_plugins:
 
                 # fix tools so they have an instance of the cat # TODO: make the cat a singleton
                 for t in plugin.tools:
@@ -213,26 +211,23 @@ class MadHatter:
         log(f"toggle plugin {plugin_id}", "WARNING")
 
         if self.plugin_exists(plugin_id):
-            
-            # get active plugins from db
-            active_plugins = self.load_active_plugins_from_db()
 
-            plugin_is_active = plugin_id in active_plugins
+            plugin_is_active = plugin_id in self.active_plugins
 
             # update list of active plugins
             if plugin_is_active:
                 # Deactivate the plugin
                 self.plugins[plugin_id].deactivate()
                 # Remove the plugin from the list of active plugins
-                active_plugins.remove(plugin_id)
+                self.active_plugins.remove(plugin_id)
             else:
                 # Activate the plugin
                 self.plugins[plugin_id].activate()
                 # Ass the plugin in the list of active plugins
-                active_plugins.append(plugin_id)
+                self.active_plugins.append(plugin_id)
 
             # update DB with list of active plugins, delete duplicate plugins
-            self.save_active_plugins_to_db(list(set(active_plugins)))
+            self.save_active_plugins_to_db(list(set(self.active_plugins)))
 
             # update cache and embeddings     
             self.sync_hooks_and_tools()

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -30,7 +30,7 @@ class MadHatter:
         self.hooks = [] # list of active plugins hooks 
         self.tools = [] # list of active plugins tools 
 
-        self.active_plugins = self.load_active_plugins_from_db()
+        self.active_plugins = []
 
         self.find_plugins()
 
@@ -79,6 +79,8 @@ class MadHatter:
         # emptying plugin dictionary, plugins will be discovered from disk
         # and stored in a dictionary plugin_id -> plugin_obj
         self.plugins = {}
+
+        self.active_plugins = self.load_active_plugins_from_db()
 
         # plugins are found in the plugins folder,
         # plus the default core plugin s(where default hooks and tools are defined)


### PR DESCRIPTION
# Description

Get active plugins from DB only when `find_plugins` is called (`find_plugins` is called also at MadHatter init), when a plugin is activated/deactivated the DB is kept in sync saving the new list of active plugins.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
