### PR TITLE
Empty plugin folder

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -109,10 +109,12 @@ class MadHatter:
         # Instantiate plugin.
         #   If the plugin is inactive, only manifest will be loaded
         #   If active, also settings, tools and hooks
-        plugin = Plugin(plugin_path, active=active)
-        
-        # if plugin is valid, keep a reference
-        self.plugins[plugin.id] = plugin
+        try:
+            plugin = Plugin(plugin_path, active=active)
+            # if plugin is valid, keep a reference
+            self.plugins[plugin.id] = plugin
+        except Exception as e:
+            log(e, "WARNING") 
 
     # Load hooks and tools of the active plugins into MadHatter 
     def sync_hooks_and_tools(self):

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -25,6 +25,13 @@ class Plugin:
         # where the plugin is on disk
         self._path: str = plugin_path
 
+        # search for .py files in folder
+        py_files_path = os.path.join(self._path, "**/*.py")
+        self.py_files = glob.glob(py_files_path, recursive=True)
+
+        if len(self.py_files) == 0:
+            raise Exception(f"{plugin_path} does not contain any python files. Cannot create Plugin.")
+
         # plugin id is just the folder name
         self._id: str = os.path.basename(os.path.normpath(plugin_path))
 
@@ -150,15 +157,10 @@ class Plugin:
 
     # lists of hooks and tools
     def _load_hooks_and_tools(self):
-
-        # search for .py files in folder
-        py_files_path = os.path.join(self._path, "**/*.py")
-        py_files = glob.glob(py_files_path, recursive=True)
-
         hooks = []
         tools = []
 
-        for py_file in py_files:
+        for py_file in self.py_files:
             py_filename = py_file.replace("/", ".").replace(".py", "")  # this is UGLY I know. I'm sorry
 
             # save a reference to decorated functions

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -27,6 +27,7 @@ def clean_up_mocks():
         "tests/mocks/metadata-test.json",
         "tests/mocks/mock_plugin.zip",
         "tests/mocks/mock_plugin_folder/mock_plugin",
+        "tests/mocks/empty_folder"
     ]
     for tbr in to_be_removed:
         if os.path.exists(tbr):

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -29,6 +29,17 @@ def test_create_plugin_wrong_folder():
         
     assert f"Cannot create" in str(e.value)
 
+def test_create_plugin_empty_folder():
+
+    path = "tests/mocks/empty_folder"
+
+    os.mkdir(path)
+
+    with pytest.raises(Exception) as e:
+        Plugin(path, active=True)
+        
+    assert f"Cannot create" in str(e.value)
+
 
 def test_create_non_active_plugin():
 


### PR DESCRIPTION
# Description

If a plugin folder contains no Python files, an exception is raised and the plugin is not added to the Mad Hatter.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
