### PR TITLE
Removed embed_tools from MadHatter

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -46,7 +46,7 @@ class CheshireCat:
         self.load_memory()
 
         # After memory is loaded, we can get/create tools embeddings
-        self.mad_hatter.embed_tools()
+        self._embed_tools()
 
         # Agent manager instance (for reasoning)
         self.agent_manager = AgentManager(self)
@@ -106,6 +106,23 @@ class CheshireCat:
         
         # Load default shared working memory user
         self.working_memory = self.working_memory_list.get_working_memory()
+
+    #realod plugins and embedd tools
+    def load_plugins(self):
+        self.mad_hatter.find_plugins()
+        self._embed_tools()
+
+    def install_plugin(self, package_plugin):
+        self.mad_hatter.install_plugin(package_plugin)
+        self._embed_tools()
+
+    def uninstall_plugin(self, plugin_id):
+        self.mad_hatter.uninstall_plugin(plugin_id)
+        self._embed_tools()
+
+    def toggle_plugin(self, plugin_id):
+        self.mad_hatter.toggle_plugin(plugin_id)
+        self._embed_tools()
 
     def recall_relevant_memories_to_working_memory(self):
         """Retrieve context from memory.
@@ -280,6 +297,50 @@ class CheshireCat:
         prompt_settings.update(user_message_json.get("prompt_settings", {}))
 
         self.working_memory["user_message_json"]["prompt_settings"] = prompt_settings
+
+    def _embed_tools(self):
+        
+        # retrieve from vectorDB all tool embeddings
+        embedded_tools = self.memory.vectors.procedural.get_all_points()
+
+        # easy acces to (point_id, tool_description)
+        embedded_tools_ids = [t.id for t in embedded_tools]
+        embedded_tools_descriptions = [t.payload["page_content"] for t in embedded_tools]
+
+        # loop over mad_hatter tools
+        for tool in self.mad_hatter.tools:
+            # if the tool is not embedded 
+            if tool.description not in embedded_tools_descriptions:
+                # embed the tool and save it to DB
+                self.memory.vectors.procedural.add_texts(
+                    [tool.description],
+                    [{
+                        "source": "tool",
+                        "when": time.time(),
+                        "name": tool.name,
+                        "docstring": tool.docstring
+                    }],
+                )
+
+                log(f"Newly embedded tool: {tool.description}", "WARNING")
+        
+        # easy access to mad hatter tools (found in plugins)
+        mad_hatter_tools_descriptions = [t.description for t in self.mad_hatter.tools]
+
+        # loop over embedded tools and delete the ones not present in active plugins
+        points_to_be_deleted = []
+        for id, descr in zip(embedded_tools_ids, embedded_tools_descriptions):
+            # if the tool is not active, it inserts it in the list of points to be deleted
+            if descr not in mad_hatter_tools_descriptions:
+                log(f"Deleting embedded tool: {descr}", "WARNING")
+                points_to_be_deleted.append(id)
+
+        # delete not active tools
+        if len(points_to_be_deleted) > 0:
+            self.memory.vectors.vector_db.delete(
+                collection_name="procedural",
+                points_selector=points_to_be_deleted
+            )        
 
     def get_base_url(self):
         """Allows the Cat expose the base url."""

--- a/core/cat/routes/embedder.py
+++ b/core/cat/routes/embedder.py
@@ -118,8 +118,8 @@ def upsert_embedder_setting(
     ccat.load_natural_language()
     # crete new collections (different embedder!)
     ccat.load_memory()
-    # recreate tools embeddings
-    ccat.mad_hatter.find_plugins()
-    ccat.mad_hatter.embed_tools()
+
+    #realod plugins and embedd tools
+    ccat.load_plugins()
 
     return status

--- a/core/cat/routes/llm.py
+++ b/core/cat/routes/llm.py
@@ -120,8 +120,8 @@ def upsert_llm_setting(
     # (in case embedder is not configured, it will be changed automatically and aligned to vendor)
     # TODO: should we take this feature away?
     ccat.load_memory()
-    # recreate tools embeddings
-    ccat.mad_hatter.find_plugins()
-    ccat.mad_hatter.embed_tools()
+    
+    #realod plugins and embedd tools
+    ccat.load_plugins()
 
     return status

--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -101,8 +101,9 @@ async def wipe_collections(
         to_return[c] = ret
 
     ccat.load_memory()  # recreate the long term memories
-    ccat.mad_hatter.find_plugins()
-    ccat.mad_hatter.embed_tools()
+
+    #realod plugins and embedd tools
+    ccat.load_plugins()
 
     return {
         "deleted": to_return,
@@ -132,8 +133,9 @@ async def wipe_single_collection(request: Request, collection_id: str) -> Dict:
     to_return[collection_id] = ret
 
     ccat.load_memory()  # recreate the long term memories
-    ccat.mad_hatter.find_plugins()
-    ccat.mad_hatter.embed_tools()
+    
+    #realod plugins and embedd tools
+    ccat.load_plugins()
 
     return {
         "deleted": to_return,

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -74,7 +74,7 @@ async def install_plugin(
         f.write(contents)
 
     background_tasks.add_task(
-        ccat.mad_hatter.install_plugin, temp.name
+        ccat.install_plugin, temp.name
     )
 
     return {
@@ -134,7 +134,7 @@ async def install_plugin_from_registry(
             
 
             background_tasks.add_task(
-                ccat.mad_hatter.install_plugin, file.name
+                ccat.install_plugin, file.name
             )
 
             return {
@@ -159,7 +159,8 @@ async def toggle_plugin(plugin_id: str, request: Request) -> Dict:
         )
     
     # toggle plugin
-    ccat.mad_hatter.toggle_plugin(plugin_id)
+    #ccat.mad_hatter.toggle_plugin(plugin_id)
+    ccat.toggle_plugin(plugin_id)
 
     return {
         "info": f"Plugin {plugin_id} toggled"
@@ -204,7 +205,7 @@ async def delete_plugin(plugin_id: str, request: Request) -> Dict:
         )
     
     # remove folder, hooks and tools
-    ccat.mad_hatter.uninstall_plugin(plugin_id)
+    ccat.uninstall_plugin(plugin_id)
 
     return {
         "deleted": plugin_id


### PR DESCRIPTION
# Description

As discussed i try to move the `embed_tools` method from the `MadHatter` to `ChechireCat`.

Furthermore i added in `CheshireCat` the following methods that take care to interact with the `MadHatter` and the vector memory to embed tools :
- `load_plugins`
- `install_plugin`
- `uninstall_plugin`
- `toggle_plugin`

In addition the previous methods add a layer of abstraction to the components of the `CheshireCat` simplifying, in my opinion, the interaction with the plugin in the code and improve the readability.

@pieroit @nicola-corbellini let me know what do you think about this solution.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
