### PR TITLE
Fix use of the fake tool `none_of_the_others`

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -124,47 +124,57 @@ class AgentManager:
          #                                         " ".join([prompt_prefix, prompt_format_instructions, prompt_suffix]))
 
 
-        # Try to get information from tools if there is some allowed
         allowed_tools = mad_hatter.execute_hook("agent_allowed_tools")
-        tools_result = None
+
+        # Try to get information from tools if there is some allowed
         if len(allowed_tools) > 0:
+
+            log(f"{len(allowed_tools)} allowed tools retrived.", "DEBUG")
+
             try:
                 tools_result = self.execute_tool_agent(agent_input, allowed_tools)
+
+                # If tools_result["output"] is None the LLM has used the fake tool none_of_the_others  
+                # so no relevant information has been obtained from the tools.
+                if tools_result["output"] != None:
+                    
+                    # Extract of intermediate steps in the format ((tool_name, tool_input), output)
+                    used_tools = list(map(lambda x:((x[0].tool, x[0].tool_input), x[1]), tools_result["intermediate_steps"]))
+
+                    # Get the name of the tools that have return_direct
+                    return_direct_tools = []
+                    for t in allowed_tools:
+                        if t.return_direct:
+                            return_direct_tools.append(t.name)
+
+                    # execute_tool_agent returns immediately when a tool with return_direct is called, 
+                    # so if one is used it is definitely the last one used
+                    if used_tools[-1][0][0] in return_direct_tools:
+                        # intermediate_steps still contains the information of all the tools used even if their output is not returned
+                        tools_result["intermediate_steps"] = used_tools
+                        return tools_result
+
+                    #Adding the tools_output key in agent input, needed by the memory chain
+                    agent_input["tools_output"] = "## Tools output: \n" + tools_result["output"] if tools_result["output"] else ""
+
+                    # Execute the memory chain
+                    out = self.execute_memory_chain(agent_input, prompt_prefix, prompt_suffix)
+
+                    # If some tools are used the intermediate step are added to the agent output
+                    out["intermediate_steps"] = used_tools
+
+                    #Early return
+                    return out
+
             except Exception as e:
                 error_description = str(e)
                 log(error_description, "ERROR")
 
+        #If an exeption occur in the execute_tool_agent or there is no allowed tools execute only the memory chain
+
         #Adding the tools_output key in agent input, needed by the memory chain
-        if tools_result != None:
-            
-            # Extract of intermediate steps in the format ((tool_name, tool_input), output)
-            used_tools = list(map(lambda x:((x[0].tool, x[0].tool_input), x[1]), tools_result["intermediate_steps"]))
-
-            # Get the name of the tools that have return_direct
-            return_direct_tools = []
-            for t in allowed_tools:
-                if t.return_direct:
-                    return_direct_tools.append(t.name)
-
-            # execute_tool_agent returns immediately when a tool with return_direct is called, 
-            # so if one is used it is definitely the last one used
-            if used_tools[-1][0][0] in return_direct_tools:
-                # intermediate_steps still contains the information of all the tools used even if their output is not returned
-                tools_result["intermediate_steps"] = used_tools
-                return tools_result
-
-            # If tools_result["output"] is None the LLM has used the fake tool none_of_the_others  
-            # so no relevant information has been obtained from the tools.
-            agent_input["tools_output"] = "## Tools output: \n" + tools_result["output"] if tools_result["output"] else ""
-
-            # Execute the memory chain
-            out = self.execute_memory_chain(agent_input, prompt_prefix, prompt_suffix)
-
-            # If some tools are used the intermediate step are added to the agent output
-            out["intermediate_steps"] = used_tools
-        else:
-            agent_input["tools_output"] = ""
-            # Execute the memory chain
-            out = self.execute_memory_chain(agent_input, prompt_prefix, prompt_suffix)
+        agent_input["tools_output"] = ""
+        # Execute the memory chain
+        out = self.execute_memory_chain(agent_input, prompt_prefix, prompt_suffix)
 
         return out

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -376,7 +376,7 @@ class CheshireCat:
             # We grab the LLM output here anyway, so small and
             #   non instruction-fine-tuned models can still be used.
             error_description = str(e)
-            log("LLM does not respect prompt instructions", "ERROR")
+
             log(error_description, "ERROR")
             if not "Could not parse LLM output: `" in error_description:
                 raise e

--- a/core/cat/looking_glass/output_parser.py
+++ b/core/cat/looking_glass/output_parser.py
@@ -23,8 +23,11 @@ class ToolOutputParser(AgentOutputParser):
         if not match:
             raise OutputParserException(f"Could not parse LLM output: `{llm_output}`")
         
-        # Check if agent decidet not tool is usefull
-        if "none_of_the_others" in llm_output:
+        # Extract action
+        action = match.group(1).strip()
+        action_input = match.group(2)
+
+        if action == "none_of_the_others":
             return AgentFinish(
                 # Return values is generally always a dictionary with a single `output` key
                 # It is not recommended to try anything else at the moment :)
@@ -32,8 +35,5 @@ class ToolOutputParser(AgentOutputParser):
                 log=llm_output,
             )
 
-        # Extract action
-        action = match.group(1).strip()
-        action_input = match.group(2)
         # Return the action and action input
         return AgentAction(tool=action, tool_input=action_input.strip(" ").strip('"'), log=llm_output)


### PR DESCRIPTION
# Description

If the tool `none_of_the_others` is used, `execute_tool_agent` returns the dictionary `{"output": None}` so the check on line 139 must be `tools_output["output"] != None` and not `tools_output != None `

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
