### PR TITLE
Add link to documentation in `Custom LLM` description

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -60,6 +60,7 @@ class LLMCustomConfig(LLMSettings):
             "description":
                 "LLM on a custom endpoint. "
                 "See docs for examples.",
+            "link": "https://cheshirecat.ai/2023/08/19/custom-large-language-model/"
         }
 
 


### PR DESCRIPTION
# Description

I added a `link` key to the `LLMCustomConfig` schema so @zAlweNy26 can point the user to the tutorial on the website. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
