### PR TITLE
Custom parser for `.doc` and `.docx` files

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -1,6 +1,5 @@
 import os
 import time
-import math
 import json
 import mimetypes
 from typing import List, Union
@@ -8,7 +7,6 @@ from urllib.request import urlopen, Request
 from urllib.parse import urlparse
 from urllib.error import HTTPError
 
-from cat.log import log
 from starlette.datastructures import UploadFile
 from langchain.docstore.document import Document
 from qdrant_client.http import models
@@ -18,6 +16,9 @@ from langchain.document_loaders.parsers.generic import MimeTypeBasedParser
 from langchain.document_loaders.parsers.txt import TextParser
 from langchain.document_loaders.blob_loaders.schema import Blob
 from langchain.document_loaders.parsers.html.bs4 import BS4HTMLParser
+
+from cat.log import log
+from cat.utils import DocxParser
 
 
 class RabbitHole:
@@ -31,7 +32,9 @@ class RabbitHole:
             "application/pdf": PDFMinerParser(),
             "text/plain": TextParser(),
             "text/markdown": TextParser(),
-            "text/html": BS4HTMLParser()
+            "text/html": BS4HTMLParser(),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": DocxParser(),
+            "application/msword": DocxParser()
         }
 
     def ingest_memory(self, file: UploadFile):

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Cheshire-Cat"
 description = "Open source and customizable AI architecture"
-version = "1.0.1"
+version = "1.0.2"
 requires-python = ">=3.10"
 license = { file="LICENSE" }
 authors = [


### PR DESCRIPTION
# Description

This PR adds a minimal custom parser for `.doc` and `.docx` files retrieving the text elements.
I put it in `utils.py`, let me know if I should move it smowhere else, please. Maybe a proper folder for the rabbit hole and its parsers. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
