### PR TITLE
Hookable `RabbitHole` parsers

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
@@ -8,10 +8,30 @@ These hooks allow to intercept the uploaded documents at different places before
 
 from typing import List
 
-from cat.log import log
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from cat.mad_hatter.decorators import hook
 from langchain.docstore.document import Document
+
+
+@hook(priority=0)
+def rabbithole_instantiates_parsers(file_handlers: dict, cat) -> dict:
+    """Hook the available parsers for ingesting files in the declarative memory.
+
+    Allows replacing or extending existing supported mime types and related parsers to customize the file ingestion.
+
+    Parameters
+    ----------
+    file_handlers : dict
+        Keys are the supported mime types and values are the related parsers.
+    cat : CheshireCat
+        Cheshire Cat instance.
+
+    Returns
+    -------
+    file_handlers : dict
+        Edited dictionary of supported mime types and related parsers.
+    """
+    return file_handlers
 
 
 # Hook called just before of inserting a document in vector memory
@@ -19,7 +39,7 @@ from langchain.docstore.document import Document
 def before_rabbithole_insert_memory(doc: Document, cat) -> Document:
     """Hook the `Document` before is inserted in the vector memory.
 
-    Allows to edit and enhance a single `Document` before the *RabbitHole* add it to the declarative vector memory.
+    Allows editing and enhancing a single `Document` before the *RabbitHole* add it to the declarative vector memory.
 
     Parameters
     ----------
@@ -51,7 +71,7 @@ def before_rabbithole_insert_memory(doc: Document, cat) -> Document:
 def before_rabbithole_splits_text(doc: Document, cat) -> Document:
     """Hook the `Document` before is split.
 
-    Allows to edit the whole uploaded `Document` before the *RabbitHole* recursively splits it in shorter ones.
+    Allows editing the whole uploaded `Document` before the *RabbitHole* recursively splits it in shorter ones.
 
     For instance, the hook allows to change the text or edit/add metadata.
 
@@ -76,7 +96,7 @@ def before_rabbithole_splits_text(doc: Document, cat) -> Document:
 def rabbithole_splits_text(text, chunk_size: int, chunk_overlap: int, cat) -> List[Document]:
     """Hook into the recursive split pipeline.
 
-    Allows to edit the recursive split the *RabbitHole* applies to chunk the ingested documents.
+    Allows editing the recursive split the *RabbitHole* applies to chunk the ingested documents.
 
     This is applied when ingesting a documents and urls from a script, using an endpoint or from the GUI.
 
@@ -120,7 +140,7 @@ def rabbithole_splits_text(text, chunk_size: int, chunk_overlap: int, cat) -> Li
 def after_rabbithole_splitted_text(chunks: List[Document], cat) -> List[Document]:
     """Hook the `Document` after is split.
 
-    Allows to edit the list of `Document` right after the *RabbitHole* chunked them in smaller ones.
+    Allows editing the list of `Document` right after the *RabbitHole* chunked them in smaller ones.
 
     Parameters
     ----------
@@ -146,7 +166,7 @@ def after_rabbithole_splitted_text(chunks: List[Document], cat) -> List[Document
 def before_rabbithole_stores_documents(docs: List[Document], cat) -> List[Document]:
     """Hook into the memory insertion pipeline.
 
-    Allows to modify how the list of `Document` is inserted in the vector memory.
+    Allows modifying how the list of `Document` is inserted in the vector memory.
 
     For example, this hook is a good point to summarize the incoming documents and save both original and
     summarized contents.

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -27,12 +27,14 @@ class RabbitHole:
     def __init__(self, cat):
         self.cat = cat
 
-        self.file_handlers = {
+        file_handlers = {
             "application/pdf": PDFMinerParser(),
             "text/plain": TextParser(),
             "text/markdown": TextParser(),
             "text/html": BS4HTMLParser()
         }
+
+        self.file_handlers = cat.mad_hatter.execute_hook("rabbithole_instantiates_parsers", file_handlers)
 
     def ingest_memory(self, file: UploadFile):
         """Upload memories to the declarative memory from a JSON file.
@@ -44,7 +46,7 @@ class RabbitHole:
 
         Notes
         -----
-        This method allows to upload a JSON file containing vector and text memories directly to the declarative memory.
+        This method allows uploading a JSON file containing vector and text memories directly to the declarative memory.
         When doing this, please, make sure the embedder used to export the memories is the same as the one used
         when uploading.
         The method also performs a check on the dimensionality of the embeddings (i.e. length of each vector).
@@ -230,7 +232,7 @@ class RabbitHole:
     def send_rabbit_thought(self, thought):
         """Append a message to the notification list.
 
-        This method receive a string and create the message to append to the list of notifications.
+        This method receives a string and creates the message to append to the list of notifications.
 
         Parameters
         ----------
@@ -244,7 +246,6 @@ class RabbitHole:
             "content": thought,
             "why": {},
         })
-
 
     def store_documents(self, docs: List[Document], source: str) -> None:
         """Add documents to the Cat's declarative memory.
@@ -278,11 +279,11 @@ class RabbitHole:
 
         # classic embed
         time_last_notification = time.time()
-        time_interval = 10 # a notification every 10 secs
+        time_interval = 10  # a notification every 10 secs
         for d, doc in enumerate(docs):
             if time.time() - time_last_notification > time_interval:
                 time_last_notification = time.time()
-                perc_read = int( d / len(docs) * 100 )
+                perc_read = int(d / len(docs) * 100)
                 self.send_rabbit_thought(f"Read {perc_read}% of {source}")
 
             doc.metadata["source"] = source
@@ -308,7 +309,7 @@ class RabbitHole:
         # notify client
         finished_reading_message = f"Finished reading {source}, " \
                                    f"I made {len(docs)} thoughts on it."
-        
+
         self.send_rabbit_thought(finished_reading_message)
 
         print(f"\n\nDone uploading {source}")


### PR DESCRIPTION
# Description

This PR adds a hook to replace or extend the `RabbitHole` file parsers to support any mime type writing plugins as @zAlweNy26 proposed during our [discussion](https://github.com/cheshire-cat-ai/core/pull/428#issuecomment-1687660292).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
