### PR TITLE
Plugin object not active by default

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -95,12 +95,12 @@ class MadHatter:
 
         # discover plugins, folder by folder
         for folder in all_plugin_folders:
+            self.load_plugin(folder)
 
-            # is the plugin active?
-            folder_base = os.path.basename(os.path.normpath(folder))
-            is_active = folder_base in self.active_plugins
-
-            self.load_plugin(folder, is_active)
+            plugin_id = os.path.basename(os.path.normpath(folder))
+            
+            if plugin_id in self.active_plugins:
+                self.plugins[plugin_id].activate()
 
         self.sync_hooks_and_tools()
 

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -52,7 +52,7 @@ class MadHatter:
             raise Exception("A plugin should contain a folder, found a file")
 
         # create plugin obj
-        self.load_plugin(plugin_path, active=False)
+        self.load_plugin(plugin_path)
 
         # activate it
         self.toggle_plugin(plugin_id)
@@ -104,12 +104,12 @@ class MadHatter:
 
         self.sync_hooks_and_tools()
 
-    def load_plugin(self, plugin_path, active):
+    def load_plugin(self, plugin_path):
         # Instantiate plugin.
         #   If the plugin is inactive, only manifest will be loaded
         #   If active, also settings, tools and hooks
         try:
-            plugin = Plugin(plugin_path, active=active)
+            plugin = Plugin(plugin_path)
             # if plugin is valid, keep a reference
             self.plugins[plugin.id] = plugin
         except Exception as e:

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -62,9 +62,12 @@ class Plugin:
 
         # Remove the imported modules
         for py_file in self.py_files:
-            py_filename = py_file.replace("/", ".").replace(".py", "")  # this is UGLY I know. I'm sorry
-            log(f"Remove module {py_filename}", "DEBUG")
-            sys.modules.pop(py_filename)
+            py_filename = py_file.replace("/", ".").replace(".py", "")
+
+            # If the module is imported it is removed
+            if py_filename in sys.modules:
+                log(f"Remove module {py_filename}", "DEBUG")
+                sys.modules.pop(py_filename)
         
         self._hooks = []
         self._tools = []

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -18,7 +18,7 @@ from cat.log import log, get_log_level
 
 class Plugin:
 
-    def __init__(self, plugin_path: str, active: bool):
+    def __init__(self, plugin_path: str):
         
         # does folder exist?
         if not os.path.exists(plugin_path) or not os.path.isdir(plugin_path):
@@ -45,12 +45,7 @@ class Plugin:
         #   but they are created and stored in each plugin instance
         self._hooks = [] 
         self._tools = []
-
         self._active = False
-
-        # all plugins start active, they can be deactivated/reactivated from endpoint
-        if active:
-            self.activate()
 
     def activate(self):
         # lists of hooks and tools
@@ -58,8 +53,6 @@ class Plugin:
         self._active = True
 
     def deactivate(self):
-        self._active = False
-
         # Remove the imported modules
         for py_file in self.py_files:
             py_filename = py_file.replace("/", ".").replace(".py", "")
@@ -71,6 +64,7 @@ class Plugin:
         
         self._hooks = []
         self._tools = []
+        self._active = False
 
     # get plugin settings JSON schema
     def get_settings_schema(self):

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -1,11 +1,7 @@
 import os
-import shutil
 import pytest
-from inspect import isfunction
 
 from cat.mad_hatter.mad_hatter import Plugin
-from cat.mad_hatter.decorators import CatHook, CatTool
-
 
 mock_plugin_path = "tests/mocks/mock_plugin/"
 

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -62,13 +62,30 @@ def test_activate_plugin(plugin):
     plugin.activate()
 
     assert plugin.active == True
-    
-    # hooks and tools
-    assert len(plugin.hooks) == 1
-    assert len(plugin.tools) == 1
 
+    # hooks
+    assert len(plugin.hooks) == 1
+    hook = plugin.hooks[0]
+    assert isinstance(hook, CatHook)
+    assert hook.plugin_id == "mock_plugin"
+    assert hook.name == "before_cat_sends_message"
+    assert isfunction(hook.function)
+    assert hook.priority == 2.0
+
+    # tools
+    assert len(plugin.tools) == 1
+    tool = plugin.tools[0]
+    assert isinstance(tool, CatTool)
+    assert tool.plugin_id == "mock_plugin"
+    assert tool.name == "mock_tool"
+    assert "mock_tool" in tool.description
+    assert isfunction(tool.func)
+    assert tool.return_direct == True
 
 def test_deactivate_plugin(plugin):
+
+    # The plugin is non active by default
+    plugin.activate()
 
     # deactivate it
     plugin.deactivate()

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -56,40 +56,6 @@ def test_create_non_active_plugin():
     assert plugin.hooks == []
     assert plugin.tools == []
 
-
-def test_create_active_plugin(plugin):
-    
-    assert plugin.active == True
-    
-    assert plugin.path == mock_plugin_path
-    assert plugin.id == "mock_plugin"
-    
-    # manifest
-    assert type(plugin.manifest) == dict
-    assert plugin.manifest["id"] == plugin.id
-    assert plugin.manifest["name"] == "MockPlugin"
-    assert "Description not found" in plugin.manifest["description"]
-
-    # hooks
-    assert len(plugin.hooks) == 1
-    hook = plugin.hooks[0]
-    assert isinstance(hook, CatHook)
-    assert hook.plugin_id == "mock_plugin"
-    assert hook.name == "before_cat_sends_message"
-    assert isfunction(hook.function)
-    assert hook.priority == 2.0
-
-    # tools
-    assert len(plugin.tools) == 1
-    tool = plugin.tools[0]
-    assert isinstance(tool, CatTool)
-    assert tool.plugin_id == "mock_plugin"
-    assert tool.name == "mock_tool"
-    assert "mock_tool" in tool.description
-    assert isfunction(tool.func)
-    assert tool.return_direct == True
-
-
 def test_activate_plugin():
 
     # create non-active plugin

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -13,7 +13,7 @@ mock_plugin_path = "tests/mocks/mock_plugin/"
 @pytest.fixture
 def plugin():
 
-    p = Plugin(mock_plugin_path, active=True)
+    p = Plugin(mock_plugin_path)
     
     yield p
     
@@ -25,7 +25,7 @@ def plugin():
 def test_create_plugin_wrong_folder():
 
     with pytest.raises(Exception) as e:
-        Plugin("/non/existent/folder", active=True)
+        Plugin("/non/existent/folder")
         
     assert f"Cannot create" in str(e.value)
 
@@ -36,14 +36,14 @@ def test_create_plugin_empty_folder():
     os.mkdir(path)
 
     with pytest.raises(Exception) as e:
-        Plugin(path, active=True)
+        Plugin(path)
         
     assert f"Cannot create" in str(e.value)
 
 
 def test_create_non_active_plugin():
 
-    plugin = Plugin(mock_plugin_path, active=False)
+    plugin = Plugin(mock_plugin_path)
 
     assert plugin.active == False
     
@@ -97,7 +97,7 @@ def test_create_active_plugin(plugin):
 def test_activate_plugin():
 
     # create non-active plugin
-    plugin = Plugin(mock_plugin_path, active=False)
+    plugin = Plugin(mock_plugin_path)
 
     # activate it
     plugin.activate()

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -37,7 +37,7 @@ def test_create_plugin_empty_folder():
     assert f"Cannot create" in str(e.value)
 
 
-def test_create_non_active_plugin():
+def test_create_plugin():
 
     plugin = Plugin(mock_plugin_path)
 

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -1,7 +1,9 @@
 import os
 import pytest
+from inspect import isfunction
 
 from cat.mad_hatter.mad_hatter import Plugin
+from cat.mad_hatter.decorators import CatHook, CatTool
 
 mock_plugin_path = "tests/mocks/mock_plugin/"
 
@@ -37,9 +39,7 @@ def test_create_plugin_empty_folder():
     assert f"Cannot create" in str(e.value)
 
 
-def test_create_plugin():
-
-    plugin = Plugin(mock_plugin_path)
+def test_create_plugin(plugin):
 
     assert plugin.active == False
     
@@ -56,10 +56,7 @@ def test_create_plugin():
     assert plugin.hooks == []
     assert plugin.tools == []
 
-def test_activate_plugin():
-
-    # create non-active plugin
-    plugin = Plugin(mock_plugin_path)
+def test_activate_plugin(plugin):
 
     # activate it
     plugin.activate()


### PR DESCRIPTION
# Description

A `Plugin` object is now create not active by default, the manifest is loaded but no modules are imported.
Aligned also tests and the `MadHatter`.

A newly installed plugin is still activated by default, this PR does not change the behavior of the `MadHatter`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
