### PR TITLE
Added allowed mime-types endpoint

### DIFF
--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -139,3 +139,16 @@ async def upload_memory(
         "content_type": file.content_type,
         "info": "Memory is being ingested asynchronously"
     }
+
+
+@router.get("/allowed-mimetypes/")
+async def get_allowed_mimetypes(request: Request) -> Dict:
+    """Retrieve the allowed mimetypes that can be ingested by the Rabbit Hole"""
+
+    ccat = request.app.state.ccat
+
+    admitted_types = [*ccat.rabbit_hole.file_handlers]
+
+    return {
+        "allowed": admitted_types
+    }

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -147,7 +147,7 @@ async def get_allowed_mimetypes(request: Request) -> Dict:
 
     ccat = request.app.state.ccat
 
-    admitted_types = [*ccat.rabbit_hole.file_handlers]
+    admitted_types = list(ccat.rabbit_hole.file_handlers.keys())
 
     return {
         "allowed": admitted_types


### PR DESCRIPTION
# Description

As discussed with the core contributors, we decided to add an endpoint to give the frontend the possibility to know in advance the allowed mime-types for a better UX.

I don't understand why `ccat.rabbit_hole.file_handlers.keys()` throws an error, so I did it in another way.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
