### PR TITLE
Updated hook decorator

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -1,7 +1,7 @@
 from langchain.prompts import PromptTemplate
 from langchain.chains import LLMChain
 from langchain.agents import AgentExecutor, LLMSingleActionAgent
-
+import traceback
 from cat.looking_glass.prompts import ToolPromptTemplate
 from cat.looking_glass.output_parser import ToolOutputParser
 from cat.log import log
@@ -151,6 +151,7 @@ class AgentManager:
             except Exception as e:
                 error_description = str(e)
                 log(error_description, "ERROR")
+                traceback.print_exc()
 
         #If an exeption occur in the execute_tool_agent or there is no allowed tools execute only the memory chain
 

--- a/core/cat/mad_hatter/decorators/hook.py
+++ b/core/cat/mad_hatter/decorators/hook.py
@@ -1,5 +1,37 @@
-from typing import Union, Callable
-# class to represent a @hook
+from typing import Union, Callable, Literal, get_args
+
+CAT_HOOKS = Literal[
+    "rabbithole_instantiates_parsers",
+    "before_rabbithole_stores_documents",
+    "before_rabbithole_insert_memory",
+    "before_rabbithole_splits_text",
+    "rabbithole_splits_text",
+    "after_rabbithole_splitted_text",
+    "agent_prompt_instructions",
+    "before_agent_starts",
+    "agent_prompt_prefix",
+    "agent_prompt_suffix",
+    "agent_allowed_tools",
+    "before_cat_bootstrap",
+    "after_cat_bootstrap",
+    "get_language_model",
+    "get_language_embedder",
+    "cat_recall_query",
+    "before_cat_recalls_memories",
+    "before_cat_recalls_episodic_memories",
+    "before_cat_recalls_declarative_memories",
+    "before_cat_recalls_procedural_memories",
+    "after_cat_recalls_memories",
+    "agent_prompt_episodic_memories",
+    "agent_prompt_declarative_memories",
+    "agent_prompt_chat_history",
+    "before_cat_reads_message",
+    "before_cat_sends_message",
+    "before_collection_created",
+    "after_collection_created",
+]
+
+# All @hook decorated functions in plugins become a CatHook.
 class CatHook:
 
     def __init__(self, function: Callable, priority: int, hook_name: str = ""):
@@ -13,20 +45,25 @@ class CatHook:
 
 # @hook decorator. Any function in a plugin decorated by @hook and named properly (among list of available hooks) is used by the Cat
 # @hook priority defaults to 1, the higher the more important. Hooks in the default core plugin have all priority=0 so they are automatically overwritten from plugins
-def hook(*args: Union[str, Callable], priority: int = 1, hook_name: str = "") -> Callable:
+def hook(*args: Union[str, Callable], priority: int = 1, name: CAT_HOOKS = "") -> Callable:
     def make_hook(func):
         return CatHook(
             func,
             priority=priority,
-            hook_name=hook_name
+            hook_name=name
         )
+    
+    options = get_args(CAT_HOOKS)
+
+    if name and name not in options:
+        raise ValueError(f"The hook `{name}` is not valid. Valid hooks: {', '.join(options)}")
     
     if len(args) == 1 and callable(args[0]):
         # called as @hook
         return CatHook(
             function=args[0],
             priority=priority,
-            hook_name=hook_name
+            hook_name=name
         )
     else:
         # called as @hook(*args, **kwargs)

--- a/core/cat/mad_hatter/decorators/hook.py
+++ b/core/cat/mad_hatter/decorators/hook.py
@@ -1,11 +1,11 @@
-
+from typing import Union, Callable
 # class to represent a @hook
 class CatHook:
 
-    def __init__(self, function, priority=1):
+    def __init__(self, function: Callable, priority: int, hook_name: str = ""):
         
         self.function = function
-        self.name = function.__name__
+        self.name = hook_name if hook_name else function.__name__
         self.priority = float(priority)
 
     def __repr__(self) -> str:
@@ -13,16 +13,21 @@ class CatHook:
 
 # @hook decorator. Any function in a plugin decorated by @hook and named properly (among list of available hooks) is used by the Cat
 # @hook priority defaults to 1, the higher the more important. Hooks in the default core plugin have all priority=0 so they are automatically overwritten from plugins
-def hook(*args, **kwargs):
+def hook(*args: Union[str, Callable], priority: int = 1, hook_name: str = "") -> Callable:
     def make_hook(func):
         return CatHook(
             func,
-            kwargs.get("priority", 1),
+            priority=priority,
+            hook_name=hook_name
         )
     
-    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+    if len(args) == 1 and callable(args[0]):
         # called as @hook
-        return CatHook(args[0])
+        return CatHook(
+            function=args[0],
+            priority=priority,
+            hook_name=hook_name
+        )
     else:
         # called as @hook(*args, **kwargs)
         return make_hook

--- a/core/cat/mad_hatter/decorators/tool.py
+++ b/core/cat/mad_hatter/decorators/tool.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union, Callable
+from typing import Union, Callable
 from inspect import signature
 
 from langchain.tools import BaseTool


### PR DESCRIPTION
# Description

In this way, a plugin developer can either define the hook using the function name or using the `name` argument of the @hook with the help of the autocomplete thanks to the Literal `CAT_HOOKS`.

Thanks to this PR, we still support the old way of defining hooks, but also adding a new and easier way to define them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
