### PR TITLE
Fixed workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,13 +1,14 @@
 name: Cheshire-Cat Action on Pull Requests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
-    branches:
-      - "main"
-      - "develop"
+    branches: [main, develop]
   push:
-    branches:
-      - "main"
-      - "develop"
+    branches: [main, develop]
 
 jobs:
   pylint:
@@ -32,12 +33,10 @@ jobs:
         run: pip install .[dev]
       - name: Pylint
         run: pylint -f actions ./
-
   test:
     needs: [ pylint ]
     name: "Run Tests"
     runs-on: 'ubuntu-latest'
-
     steps:
       - uses: actions/checkout@v2
       - name: Cat up

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,8 +6,7 @@ concurrency:
 
 on:
   push:
-    branches:
-      - "main"
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
# Description

In this way, when a workflow of the same group has to start, it stops the one that is running before, decreasing the load on the poor Github (sorry Microsoft).

For example, if a PR adds 2 new commits one after another in just a few seconds, the one running before will be stopped. It is useless to see the results of that one as the new one is more important.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
