### PR TITLE
Plugin module name in log messages

### DIFF
--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -121,6 +121,10 @@ class CatLogEngine:
             package = mod[0]
             module = mod[1]
 
+            # When the module is "plugins" get also the plugin module name
+            if module == "plugins":
+                module = ".".join(mod[1:])
+
         # class name.
         klass = None
         if "self" in parentframe.f_locals:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related to issue #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

When using `cat.log` from a plugin, there is no reference to the plugin that printed the message:
`cheshire_cat_core           | [2023-09-05 20:25:06.596] WARNING cat.plugins.None.wait_for_client::60 => ('Waiting for debug sessions on port 5678, attach with VSCode to continue '`

With this change, when the module is "plugins", we print the complete module name eg:
`cheshire_cat_core           | [2023-09-05 20:04:42.150] WARNING cat.plugins.cc-vscode-debugpy.cc-vscode-debugpy.None.wait_for_client::60 => ('Waiting for debug sessions on port 5678, attach with VSCode to continue '`