### PR TITLE
Add list of hooks and tools when fetching plugins

### DIFF
--- a/core/cat/mad_hatter/decorators/tool.py
+++ b/core/cat/mad_hatter/decorators/tool.py
@@ -12,6 +12,8 @@ class CatTool(Tool):
     def augment_tool(self, cat_instance):
         
         self.cat = cat_instance
+
+        self.name = self.func.__name__
         
         # Tool docstring, is also available under self.func.__doc__
         self.docstring = self.func.__doc__

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -40,8 +40,8 @@ async def get_available_plugins(
         # get manifest
         manifest = deepcopy(p.manifest) # we make a copy to avoid modifying the plugin obj
         manifest["active"] = p.id in active_plugins # pass along if plugin is active or not
-        manifest["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in p.hooks]
-        manifest["used_tools"] = [tool.func.__name__ for tool in p.tools]
+        manifest["hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in p.hooks]
+        manifest["tools"] = [{ "name": tool.name } for tool in p.tools]
         
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]
@@ -179,8 +179,8 @@ async def get_plugin_details(plugin_id: str, request: Request) -> Dict:
     # get manifest and active True/False. We make a copy to avoid modifying the original obj
     plugin_info = deepcopy(plugin.manifest)
     plugin_info["active"] = plugin_id in active_plugins
-    plugin_info["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in plugin.hooks]
-    plugin_info["used_tools"] = [tool.func.__name__ for tool in plugin.tools]
+    plugin_info["hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in plugin.hooks]
+    plugin_info["tools"] = [{ "name": tool.name } for tool in plugin.tools]
 
     return {
         "data": plugin_info

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -40,7 +40,7 @@ async def get_available_plugins(
         # get manifest
         manifest = deepcopy(p.manifest) # we make a copy to avoid modifying the plugin obj
         manifest["active"] = p.id in active_plugins # pass along if plugin is active or not
-        manifest["used_hooks"] = [hook.name for hook in p.hooks]
+        manifest["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in p.hooks]
         
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]
@@ -49,7 +49,7 @@ async def get_available_plugins(
             installed_plugins.append(manifest)
 
         # do not show already installed plugins among registry plugins
-        registry_plugins_index.pop( manifest["plugin_url"], None )
+        registry_plugins_index.pop(manifest["plugin_url"], None)
 
     return {
         "filters": {

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -41,6 +41,7 @@ async def get_available_plugins(
         manifest = deepcopy(p.manifest) # we make a copy to avoid modifying the plugin obj
         manifest["active"] = p.id in active_plugins # pass along if plugin is active or not
         manifest["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in p.hooks]
+        manifest["used_tools"] = [tool.func.__name__ for tool in p.tools]
         
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]
@@ -179,6 +180,7 @@ async def get_plugin_details(plugin_id: str, request: Request) -> Dict:
     plugin_info = deepcopy(plugin.manifest)
     plugin_info["active"] = plugin_id in active_plugins
     plugin_info["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in plugin.hooks]
+    plugin_info["used_tools"] = [tool.func.__name__ for tool in plugin.tools]
 
     return {
         "data": plugin_info

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -173,9 +173,12 @@ async def get_plugin_details(plugin_id: str, request: Request) -> Dict:
 
     active_plugins = ccat.mad_hatter.load_active_plugins_from_db()
 
+    plugin = ccat.mad_hatter.plugins[plugin_id]
+
     # get manifest and active True/False. We make a copy to avoid modifying the original obj
-    plugin_info = deepcopy(ccat.mad_hatter.plugins[plugin_id].manifest)
+    plugin_info = deepcopy(plugin.manifest)
     plugin_info["active"] = plugin_id in active_plugins
+    plugin_info["used_hooks"] = [{ "name": hook.name, "priority": hook.priority } for hook in plugin.hooks]
 
     return {
         "data": plugin_info

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -40,6 +40,7 @@ async def get_available_plugins(
         # get manifest
         manifest = deepcopy(p.manifest) # we make a copy to avoid modifying the plugin obj
         manifest["active"] = p.id in active_plugins # pass along if plugin is active or not
+        manifest["used_hooks"] = [hook.name for hook in p.hooks]
         
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]


### PR DESCRIPTION
# Description

In this way, you can visualize in the frontend or from a generic client, the used hooks by each plugin and their priority, for a better understanding of the flow of the plugins you installed. You can also see the tools created by the plugins.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
