### PR TITLE
updated model_name for openAI GPT-3 LM

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -139,8 +139,8 @@ class LLMAzureOpenAIConfig(LLMSettings):
     # Current supported versions 2022-12-01, 2023-03-15-preview, 2023-05-15
     # Don't mix api versions: https://github.com/hwchase17/langchain/issues/4775
     api_version: str = "2023-05-15"
-    deployment_name: str = "gpt-35-turbo"
-    model_name: str = "gpt-35-turbo"  # Use only completion models !
+    deployment_name: str = "gpt-35-turbo-instruct" # Model "comming soon" according to microsoft
+    model_name: str = "gpt-35-turbo-instruct"  # Use only completion models !
 
     _pyclass: PyObject = langchain.llms.AzureOpenAI
 

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -96,7 +96,7 @@ class LLMOpenAIChatConfig(LLMSettings):
 
 class LLMOpenAIConfig(LLMSettings):
     openai_api_key: str
-    model_name: str = "gpt-3.5-turbo-instruct"
+    model_name: str = "gpt-3.5-turbo-instruct" # used instead of text-davinci-003 since it deprecated
     _pyclass: PyObject = langchain.llms.OpenAI
 
     class Config:
@@ -139,8 +139,8 @@ class LLMAzureOpenAIConfig(LLMSettings):
     # Current supported versions 2022-12-01, 2023-03-15-preview, 2023-05-15
     # Don't mix api versions: https://github.com/hwchase17/langchain/issues/4775
     api_version: str = "2023-05-15"
-    deployment_name: str = "text-davinci-003"
-    model_name: str = "text-davinci-003"  # Use only completion models !
+    deployment_name: str = "gpt-35-turbo"
+    model_name: str = "gpt-35-turbo"  # Use only completion models !
 
     _pyclass: PyObject = langchain.llms.AzureOpenAI
 

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -96,7 +96,7 @@ class LLMOpenAIChatConfig(LLMSettings):
 
 class LLMOpenAIConfig(LLMSettings):
     openai_api_key: str
-    model_name: str = "text-davinci-003"
+    model_name: str = "gpt-3.5-turbo-instruct"
     _pyclass: PyObject = langchain.llms.OpenAI
 
     class Config:


### PR DESCRIPTION
# Description

updating model name for openAI completion model from text-davinci-003 to gpt-3.5-turbo-instruct since [text-davinci-003 will deprecate soon](https://openai.com/blog/gpt-4-api-general-availability#:~:text=chattiness%E2%80%9D%20of%20responses.-,Deprecation%20of%20older%20models%20in%20the%20Completions%20API,-As%20part%20of)
Related to issue #464

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
