### PR TITLE
Opt-in memory collections' snapshopts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,5 @@ CORE_PORT=1865
 # Log levels
 LOG_LEVEL=WARNING
 
-# Turn off memory collections' snapshots on embedder change
+# Turn on memory collections' snapshots on embedder change with SAVE_MEMORY_SNAPSHOTS=true
 SAVE_MEMORY_SNAPSHOTS=false

--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,5 @@ CORE_PORT=1865
 # Log levels
 LOG_LEVEL=WARNING
 
-# Turn off memory collections' snapshots on embeddder change
+# Turn off memory collections' snapshots on embedder change
 SAVE_MEMORY_SNAPSHOTS=false

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ CORE_PORT=1865
 
 # Log levels
 LOG_LEVEL=WARNING
+
+# Turn off memory collections' snapshots on embeddder change
+SAVE_MEMORY_SNAPSHOTS=false

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -129,9 +129,8 @@ class VectorMemoryCollection(Qdrant):
             log.info(f'Collection "{self.collection_name}" has the same embedder')
         else:
             log.warning(f'Collection "{self.collection_name}" has different embedder')
-            # Opt-in memory snapshot saving can be turned off in the .env file with:
+            # Memory snapshot saving can be turned off in the .env file with:
             # SAVE_MEMORY_SNAPSHOTS=false
-            log.critical(os.getenv("SAVE_MEMORY_SNAPSHOTS"))
             if os.getenv("SAVE_MEMORY_SNAPSHOTS") == "true":
                 # dump collection on disk before deleting
                 self.save_dump()

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -129,9 +129,13 @@ class VectorMemoryCollection(Qdrant):
             log.info(f'Collection "{self.collection_name}" has the same embedder')
         else:
             log.warning(f'Collection "{self.collection_name}" has different embedder')
-            # dump collection on disk before deleting
-            self.save_dump()
-            log.info(f'Dump "{self.collection_name}" completed')
+            # Opt-in memory snapshot saving can be turned off in the .env file with:
+            # SAVE_MEMORY_SNAPSHOTS=false
+            log.critical(os.getenv("SAVE_MEMORY_SNAPSHOTS"))
+            if os.getenv("SAVE_MEMORY_SNAPSHOTS") == "true":
+                # dump collection on disk before deleting
+                self.save_dump()
+                log.info(f'Dump "{self.collection_name}" completed')
 
             self.client.delete_collection(self.collection_name)
             log.warning(f'Collection "{self.collection_name}" deleted')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - API_KEY=${API_KEY:-}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - DEBUG=${DEBUG:-true}
-      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-true}
+      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-false}
     ports:
       - ${CORE_PORT:-1865}:80
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - API_KEY=${API_KEY:-}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - DEBUG=${DEBUG:-true}
+      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-true}
     ports:
       - ${CORE_PORT:-1865}:80
     volumes:


### PR DESCRIPTION
# Description

Now, saving the vector memory collections' snapshots is optional.
Default behavior is saving the snapshots, but this can be turned off setting `SAVE_MEMORY_SNAPSHOTS=false` in the `.env` file.

Related to issue #463 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
