### PR TITLE
Fixed the rate limit issue for openai embedder

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -2,7 +2,7 @@ import langchain
 from pydantic import PyObject, BaseSettings
 
 from cat.factory.custom_embedder import DumbEmbedder, CustomOpenAIEmbeddings
-
+from cat.utils import check_openai_key_valid
 
 # Base class to manage LLM configuration.
 class EmbedderSettings(BaseSettings):
@@ -62,6 +62,16 @@ class EmbedderOpenAIConfig(EmbedderSettings):
             "humanReadableName": "OpenAI Embedder",
             "description": "Configuration for OpenAI embeddings",
         }
+    
+    # instantiate an open ai Embedder from configuration with checking for the validity of the key
+    @classmethod
+    def get_embedder_from_config(cls, config):
+        if cls._pyclass is None:
+            raise Exception(
+                "Embedder configuration class has self._pyclass = None. Should be a valid Embedder class"
+            )
+        check_openai_key_valid(config["openai_api_key"])
+        return cls._pyclass(**config)
 
 
 # https://python.langchain.com/en/latest/_modules/langchain/embeddings/openai.html#OpenAIEmbeddings
@@ -81,6 +91,15 @@ class EmbedderAzureOpenAIConfig(EmbedderSettings):
             "description": "Configuration for Azure OpenAI embeddings",
         }
 
+    # instantiate an open ai Embedder from configuration with checking for the validity of the key
+    @classmethod
+    def get_embedder_from_config(cls, config):
+        if cls._pyclass is None:
+            raise Exception(
+                "Embedder configuration class has self._pyclass = None. Should be a valid Embedder class"
+            )
+        check_openai_key_valid(config["openai_api_key"])
+        return cls._pyclass(**config)
 
 class EmbedderCohereConfig(EmbedderSettings):
     cohere_api_key: str

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -22,7 +22,7 @@ from langchain.base_language import BaseLanguageModel
 from langchain import HuggingFaceHub
 from langchain.chat_models import AzureChatOpenAI
 from cat.factory.custom_llm import CustomOpenAI
-
+from openai.error import RateLimitError
 
 MSG_TYPES = Literal["notification", "chat", "error"]
 
@@ -159,8 +159,11 @@ class CheshireCat:
 
             # obtain configuration and instantiate Embedder
             selected_embedder_config = crud.get_setting_by_name(name=selected_embedder_class)
-            embedder = FactoryClass.get_embedder_from_config(selected_embedder_config["value"])
-
+            try:
+                embedder = FactoryClass.get_embedder_from_config(selected_embedder_config["value"])
+            except Exception as e:
+                embedder = embedders.EmbedderDumbConfig.get_embedder_from_config({})
+                log.log(f"A problem occured while loading the embedder, the default embadder will be used, {str(e)}", "WARNING")
             return embedder
 
         # OpenAI embedder

--- a/core/cat/routes/embedder.py
+++ b/core/cat/routes/embedder.py
@@ -5,6 +5,9 @@ from fastapi import Request, APIRouter, Body, HTTPException
 from cat.factory.embedder import EMBEDDER_SCHEMAS, SUPPORTED_EMDEDDING_MODELS
 from cat.db import crud, models
 from cat.log import log
+from cat.utils import check_openai_key_valid
+
+import openai
 
 router = APIRouter()
 
@@ -105,6 +108,18 @@ def upsert_embedder_setting(
             }
         )
     
+    # check if the openai key is valid
+    if "openai_api_key" in payload:
+        try:
+            check_openai_key_valid(payload["openai_api_key"])
+        except Exception as e:
+            raise HTTPException(
+            status_code=400,
+            detail={
+                "error": str(e)
+            }
+        )
+
     # create the setting and upsert it
     final_setting = crud.upsert_setting_by_name(
         models.Setting(name=languageEmbedderName, category=EMBEDDER_CATEGORY, value=payload)
@@ -129,3 +144,4 @@ def upsert_embedder_setting(
     ccat.mad_hatter.embed_tools()
 
     return status
+    

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -1,7 +1,7 @@
 """Various utiles used from the projects."""
 
 from datetime import timedelta
-
+import openai
 
 def to_camel_case(text :str ) -> str:
     """Format string to camel case.
@@ -67,3 +67,26 @@ def verbal_timedelta(td: timedelta) -> str:
         return "{} ago".format(abs_delta)
     else:
         return "{} ago".format(abs_delta)
+    
+def check_openai_key_valid(key):
+    """send a request to the openai api to test the key.
+
+    The fucntion send a request to the openai api using the given key and check the response, if the key is not valid an exception will be raised.
+
+    Parameters
+    ----------
+    key : str
+        openai key.
+
+    Returns
+    -------
+    str
+        response to the query.
+    """
+    openai.api_key = key
+    response = openai.Completion.create(
+        engine="davinci",
+        prompt="test for the key",
+        max_tokens=5
+    )
+    return response


### PR DESCRIPTION
# Description

Previously there was no check to make sure that the openai key used when setting up an openai embedder was not expired. I added two checks:

1. When inserting the key: an error will be shown and the user will have to insert a new key.
2. Every time the cat is instantiated: this is done becuase the user can still insert a valid key which could expire in the following days and this could cause problems when the cat is launched. To avoid this, the check is re-executed at any instantiation of the cat and if a non-valid key is detected then the embedder is set to DumbEmbedder and a warning is logged in the console.

Related to issue #461 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
