### PR TITLE
Install plugins requirements at runtime

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -282,7 +282,7 @@ class MadHatter:
                     *deepcopy(args[1:]),
                     cat=self.ccat
                 )
-                log.debug(f"Hook {hook.plugin_id}::{hook.name} returned {tea_spoon}")
+                #log.debug(f"Hook {hook.plugin_id}::{hook.name} returned {tea_spoon}")
                 if tea_spoon is not None:
                     tea_cup = tea_spoon
             except Exception as e:

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -40,6 +40,8 @@ class Plugin:
         # plugin manifest (name, decription, thumb, etc.)
         self._manifest = self._load_manifest()
 
+        self._install_requirements()
+
         # list of tools and hooks contained in the plugin.
         #   The MadHatter will cache them for easier access,
         #   but they are created and stored in each plugin instance
@@ -166,6 +168,14 @@ class Plugin:
         meta["version"] = json_file_data.get("version", "0.0.1")
 
         return meta
+    
+    def _install_requirements(self):
+        req_file = os.path.join(self.path, "requirements.txt")
+
+        if os.path.exists(req_file):
+            log.critical(f"Installing requirements for: {self.id}")
+            os.system(f'pip install --no-cache-dir -r "{req_file}"')
+
 
     # lists of hooks and tools
     def _load_decorated_functions(self):

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -35,6 +35,9 @@ def clean_up_mocks():
                 shutil.rmtree(tbr)
             else:
                 os.remove(tbr)
+    
+    # Uninstall mock plugin requirements
+    os.system("pip uninstall -y pip-install-test")
 
 
 @pytest.fixture(scope="function")

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -1,5 +1,8 @@
 import os
 import pytest
+import fnmatch
+import subprocess
+
 from inspect import isfunction
 
 from cat.mad_hatter.mad_hatter import Plugin
@@ -52,9 +55,15 @@ def test_create_plugin(plugin):
     assert plugin.manifest["name"] == "MockPlugin"
     assert "Description not found" in plugin.manifest["description"]
 
+    # Check if plugin requirement is installed
+    result = subprocess.run(['pip', 'list'], stdout=subprocess.PIPE)
+    result = result.stdout.decode()
+    assert fnmatch.fnmatch(result, "*pip-install-test*")
+
     # hooks and tools
     assert plugin.hooks == []
     assert plugin.tools == []
+
 
 def test_activate_plugin(plugin):
 

--- a/core/tests/mocks/mock_plugin/requirements.txt
+++ b/core/tests/mocks/mock_plugin/requirements.txt
@@ -1,0 +1,1 @@
+pip-install-test


### PR DESCRIPTION
# Description

With this PR the plugins dependencies are now installed at runtime, so as to avoid to rebuild the container for each plugin installed. 

However, this does not replace the build because in this way every requirement of the plugins you install will be reinstalled when the Cheshire Cat is restarted (slowing down the bootstrap), however making the build the requirements will be permanently installed in the container.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
