### PR TITLE
OpenAI temperature setting added

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -84,6 +84,7 @@ class LLMLlamaCppConfig(LLMSettings):
 class LLMOpenAIChatConfig(LLMSettings):
     openai_api_key: str
     model_name: str = "gpt-3.5-turbo"
+    temperature: float = 0.7 # default value, from 0 to 1. Higher value create more creative and randomic answers, lower value create more focused and deterministc answers
     _pyclass: PyObject = langchain.chat_models.ChatOpenAI
 
     class Config:
@@ -97,6 +98,7 @@ class LLMOpenAIChatConfig(LLMSettings):
 class LLMOpenAIConfig(LLMSettings):
     openai_api_key: str
     model_name: str = "gpt-3.5-turbo-instruct" # used instead of text-davinci-003 since it deprecated
+    temperature: float = 0.7 # default value, from 0 to 1. Higher value create more creative and randomic answers, lower value create more focused and deterministc answers
     _pyclass: PyObject = langchain.llms.OpenAI
 
     class Config:


### PR DESCRIPTION
# Description

I've implemented the feature that allows users to set the "temperature" in requests made via OpenAI's API. I've set a default value of 0.7.

Temperature is a parameter that influences the creativity of the model's responses:

Lower values (e.g., 0.2) make the output more deterministic and closely tied to the context of the provided prompt.
Higher values (e.g., 0.8 or above) make the output more random and creative, potentially deviating from the prompt's context.
While in the past the acceptable range for temperature was between 0.0 and 1.0, it now seems that OpenAI allows values up to 2.0. However, there's some ambiguity in OpenAI's documentation as it mentions that values above 0.8 would produce more random outputs, but the default is now set to 1.

Given this uncertainty, I've chosen not to impose a maximum limit on the temperature parameter. I suggest monitoring any updates from OpenAI's documentation and, if necessary, adjust our default value or the accepted range at a later date.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
