### PR TITLE
Make `cat.ws_messages` an async queue

### DIFF
--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -70,13 +70,10 @@ async def check_messages(websocket: WebSocket, ccat):
     Periodically check if there are any new notifications from the `ccat` instance and send them to the user.
     """
     while True:
-        if ccat.ws_messages:
-            # extract from FIFO list websocket notification
-            notification = ccat.ws_messages.pop(0)
-            await manager.send_personal_message(notification, websocket)
 
-        # Sleep for the specified interval before checking for notifications again.
-        await asyncio.sleep(QUEUE_CHECK_INTERVAL)
+        # extract from FIFO list websocket notification
+        notification = await ccat.ws_messages.get()
+        await manager.send_personal_message(notification, websocket)
 
 
 @router.websocket_route("/ws")


### PR DESCRIPTION
# Description

I made the `cat.ws_messages`  an an asynchronous queue,  so the [check_messages](https://github.com/cheshire-cat-ai/core/blob/c96bbb72ac5770d1f666e86071698f31710b6b11/core/cat/routes/websocket.py#L68)  function doesn't need to check if there are messages in the queue and send them every [QUEUE_CHECK_INTERVAL](https://github.com/cheshire-cat-ai/core/blob/c96bbb72ac5770d1f666e86071698f31710b6b11/core/cat/routes/websocket.py#L11C10-L11C10) seconds but sends messages as soon as they are queued.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
