### PR TITLE
add support for streaming

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y update && apt-get install -y curl build-essential fastjar libmagi
 
 ### ADMIN (static build) ###
 WORKDIR /admin
-RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
+RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/release.zip | jar -xv
 
 ### INSTALL PYTHON DEPENDENCIES (Core and Plugins) ###
 WORKDIR /app

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -97,6 +97,7 @@ class LLMOpenAIChatConfig(LLMSettings):
     openai_api_key: str
     model_name: str = "gpt-3.5-turbo"
     temperature: float = 0.7 # default value, from 0 to 1. Higher value create more creative and randomic answers, lower value create more focused and deterministc answers
+    streaming: bool = False
     _pyclass: Type = ChatOpenAI
 
     model_config = ConfigDict(

--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -12,7 +12,16 @@ from cat.looking_glass import prompts
 from cat.looking_glass.output_parser import ToolOutputParser
 from cat.utils import verbal_timedelta
 from cat.log import log
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.callbacks.base import BaseCallbackHandler
 
+
+class MyCustomHandler(BaseCallbackHandler):
+
+    def __init__(self, cat):
+        self.cat = cat
+    def on_llm_new_token(self, token: str, **kwargs) -> None:
+        self.cat.send_ws_message(token, "chat_token")
 
 
 
@@ -85,7 +94,7 @@ class AgentManager:
             verbose=True
         )
 
-        out = memory_chain(agent_input)
+        out = memory_chain(agent_input, callbacks=[MyCustomHandler(self.cat)])
         out["output"] = out["text"]
         del out["text"]
         return out

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -23,7 +23,7 @@ from langchain.base_language import BaseLanguageModel
 from cat.factory.custom_llm import CustomOpenAI
 
 
-MSG_TYPES = Literal["notification", "chat", "error"]
+MSG_TYPES = Literal["notification", "chat", "error", "chat_token"]
 
 # main class
 class CheshireCat:


### PR DESCRIPTION


# Description

This feature add support for streaming by a callback, required boolean to chatopenai config to enable it,
a new type of message on the websocket named "chat_token"



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
