### PR TITLE
Fix plugin settings loading

### DIFF
--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from cat.mad_hatter.decorators import CatTool, CatHook, CatPluginOverride
 from cat.utils import to_camel_case
-from cat.log import log, get_log_level
+from cat.log import log
 
 
 # Empty class to represent basic plugin Settings model
@@ -83,7 +83,7 @@ class Plugin:
     # get plugin settings JSON schema
     def settings_schema(self):
 
-        # is "plugin_settings_schema" hook defined in the plugin?
+        # is "settings_schema" hook defined in the plugin?
         for h in self._plugin_overrides:
             if h.name == "settings_schema":
                 return h.function()
@@ -94,7 +94,7 @@ class Plugin:
     # load plugin settings
     def load_settings(self):
 
-        # is "plugin_settings_load" hook defined in the plugin?
+        # is "settings_load" hook defined in the plugin?
         for h in self._plugin_overrides:
             if h.name == "load_settings":
                 return h.function()
@@ -114,13 +114,14 @@ class Plugin:
             except Exception as e:
                 log.error(f"Unable to load plugin {self._id} settings")
                 log.error(e)
+                raise e
 
         return settings
     
     # save plugin settings
     def save_settings(self, settings: Dict):
 
-        # is "plugin_settings_save" hook defined in the plugin?
+        # is "settings_save" hook defined in the plugin?
         for h in self._plugin_overrides:
             if h.name == "save_settings":
                 return h.function(settings)
@@ -181,7 +182,6 @@ class Plugin:
         if os.path.exists(req_file):
             log.info(f"Installing requirements for: {self.id}")
             os.system(f'pip install --no-cache-dir -r "{req_file}"')
-
 
     # lists of hooks and tools
     def _load_decorated_functions(self):

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -219,15 +219,18 @@ async def get_plugins_settings(request: Request) -> Dict:
 
     # plugins are managed by the MadHatter class
     for plugin in ccat.mad_hatter.plugins.values():
-        plugin_settings = plugin.load_settings()
-        plugin_schema = plugin.settings_schema()
-        if plugin_schema['properties'] == {}:
-            plugin_schema = {}
-        settings.append({
-            "name": plugin.id,
-            "value": plugin_settings,
-            "schema": plugin_schema
-        })
+        try:
+            plugin_settings = plugin.load_settings()
+            plugin_schema = plugin.settings_schema()
+            if plugin_schema['properties'] == {}:
+                plugin_schema = {}
+            settings.append({
+                "name": plugin.id,
+                "value": plugin_settings,
+                "schema": plugin_schema
+            })
+        except:
+            log.error(f"Error loading {plugin} settings")
 
     return {
         "settings": settings,


### PR DESCRIPTION
# Description

This PR resolves a bug by which if an error occurs while loading the settings of a plugin, the call to the [plugins/settings/](https://github.com/cheshire-cat-ai/core/blob/464bbe3cbc9a6c544701f1ec478a120df3f288d7/core/cat/routes/plugins.py#L212) endpoint results in an internal server error, but now the settings of the plugin that generates the error are not added to the list so that the endpoint can function properly.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
