### PR TITLE
Plugin settings validation

### DIFF
--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -87,9 +87,26 @@ class Plugin:
         for h in self._plugin_overrides:
             if h.name == "settings_schema":
                 return h.function()
+            else:
+                # if the "settings_schema" is not defined but 
+                # "settings_model" is it get the schema from the model
+                if h.name == "settings_model":
+                    return h.function().model_json_schema()
 
         # default schema (empty)
         return PluginSettingsModel.model_json_schema()
+
+    # get plugin settings Pydantic model
+    def settings_model(self):
+
+        # is "settings_model" hook defined in the plugin?
+        for h in self._plugin_overrides:
+            if h.name == "settings_model":
+                return h.function()
+
+        # default schema (empty)
+        return PluginSettingsModel
+
 
     # load plugin settings
     def load_settings(self):


### PR DESCRIPTION
# Description

This PR adds validation of plugin settings using the Pydantic model. To do this, the `settings_model` method was added to the [Plugin](https://github.com/cheshire-cat-ai/core/blob/main/core/cat/mad_hatter/plugin.py#L25C10-L25C10) class for use in plugins with the `@plugin` decorator as well as `settings_schema`, returning in it the settings model defined in the plugin.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
