### PR TITLE
Added user_id to websocket route

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -1,7 +1,8 @@
 import time
 from copy import deepcopy
 import traceback
-from typing import Literal, get_args
+from typing import Literal, get_args, Dict
+import langchain
 import os
 import asyncio
 import langchain
@@ -71,7 +72,7 @@ class CheshireCat:
 
         # queue of cat messages not directly related to last user input
         # i.e. finished uploading a file
-        self.ws_messages = asyncio.Queue()     
+        self.ws_messages: Dict[str, asyncio.Queue] = {}
 
     def load_natural_language(self):
         """Load Natural Language related objects.
@@ -345,7 +346,7 @@ class CheshireCat:
         if isinstance(self._llm, langchain.chat_models.base.BaseChatModel):
             return self._llm.call_as_llm(prompt, callbacks=callbacks)
 
-    def send_ws_message(self, content: str, msg_type: MSG_TYPES = "notification"):
+    def send_ws_message(self, content: str, msg_type: MSG_TYPES = "notification", user_id: str = "user"):
         """Send a message via websocket.
 
         This method is useful for sending a message via websocket directly without passing through the LLM
@@ -365,7 +366,7 @@ class CheshireCat:
 
         if msg_type == "error":
             asyncio.run(
-                self.ws_messages.put( 
+                self.ws_messages[user_id].put( 
                     {
                         "type": msg_type,
                         "name": "GenericError",
@@ -375,7 +376,7 @@ class CheshireCat:
             )
         else:
             asyncio.run(
-                self.ws_messages.put(
+                self.ws_messages[user_id].put(
                     {
                         "type": msg_type,
                         "content": content

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -363,6 +363,9 @@ class CheshireCat:
 
         if msg_type not in options:
             raise ValueError(f"The message type `{msg_type}` is not valid. Valid types: {', '.join(options)}")
+        
+        if user_id not in self.ws_messages:
+            self.ws_messages[user_id] = asyncio.Queue()
 
         if msg_type == "error":
             asyncio.run(

--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -41,7 +41,6 @@ def custom_generate_unique_id(route: APIRoute):
 # REST API
 cheshire_cat_api = FastAPI(
     lifespan=lifespan,
-    dependencies=[Depends(check_api_key)],
     generate_unique_id_function=custom_generate_unique_id
 )
 
@@ -57,13 +56,14 @@ cheshire_cat_api.add_middleware(
 )
 
 # Add routers to the middleware stack.
-cheshire_cat_api.include_router(base.router, tags=["Status"])
-cheshire_cat_api.include_router(settings.router, tags=["Settings"], prefix="/settings")
-cheshire_cat_api.include_router(llm.router, tags=["Large Language Model"], prefix="/llm")
-cheshire_cat_api.include_router(embedder.router, tags=["Embedder"], prefix="/embedder")
-cheshire_cat_api.include_router(plugins.router, tags=["Plugins"], prefix="/plugins")
-cheshire_cat_api.include_router(memory.router, tags=["Memory"], prefix="/memory")
-cheshire_cat_api.include_router(upload.router, tags=["Rabbit Hole"], prefix="/rabbithole")
+# TODO: To workaround the dependencies of the websocket, their are added manually in each router
+cheshire_cat_api.include_router(base.router, tags=["Status"], dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(settings.router, tags=["Settings"], prefix="/settings", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(llm.router, tags=["Large Language Model"], prefix="/llm", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(embedder.router, tags=["Embedder"], prefix="/embedder", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(plugins.router, tags=["Plugins"], prefix="/plugins", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(memory.router, tags=["Memory"], prefix="/memory", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(upload.router, tags=["Rabbit Hole"], prefix="/rabbithole", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(websocket.router, tags=["Websocket"])
 
 # mount static files

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -55,26 +55,28 @@ async def receive_message(ccat: object, user_id: str = "user"):
     """
     Continuously receive messages from the WebSocket and forward them to the `ccat` object for processing.
     """
-    ws = manager.active_connections[user_id]
     while True:
-        user_message = await ws.receive_json()
+        user_message = await manager.active_connections[user_id].receive_json()
 
         # Run the `ccat` object's method in a threadpool since it might be a CPU-bound operation.
         cat_message = await run_in_threadpool(ccat, user_message)
 
         # Send the response message back to the user.
-        await manager.send_personal_message(cat_message, ws)
+        await manager.send_personal_message(cat_message, user_id)
 
 
 async def check_messages(ccat, user_id: str = "user"):
     """
     Periodically check if there are any new notifications from the `ccat` instance and send them to the user.
     """
-    while True:
+    if user_id not in ccat.ws_messages:
+        ccat.ws_messages[user_id] = asyncio.Queue()
 
+    while True:
         # extract from FIFO list websocket notification
+        
         notification = await ccat.ws_messages[user_id].get()
-        await manager.send_personal_message(notification, manager.active_connections[user_id])
+        await manager.send_personal_message(notification, user_id)
 
 
 @router.websocket_route("/ws")
@@ -110,7 +112,7 @@ async def websocket_endpoint(websocket: WebSocket, user_id: Optional[str] = None
             "type": "error",
             "name": type(e).__name__,
             "description": str(e),
-        }, websocket)
+        }, user_id)
     finally:
         # Always ensure the WebSocket is removed from the manager, regardless of how the above block exits.
         manager.disconnect(ccat, websocket)

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -1,6 +1,6 @@
 import traceback
 import asyncio
-
+from typing import Dict
 from fastapi import APIRouter, WebSocketDisconnect, WebSocket
 from cat.log import log
 from fastapi.concurrency import run_in_threadpool
@@ -18,62 +18,63 @@ class ConnectionManager:
 
     def __init__(self):
         # List to store all active WebSocket connections.
-        self.active_connections: list[WebSocket] = []
+        self.active_connections: Dict[str, WebSocket] = {}
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket, user_id: str = "user"):
         """
         Accept the incoming WebSocket connection and add it to the active connections list.
         """
-
         await websocket.accept()
-        self.active_connections.append(websocket)
+        self.active_connections[user_id].append(websocket)
 
-    def disconnect(self, websocket: WebSocket):
+    def disconnect(self, ccat: object, user_id: str = "user"):
         """
         Remove the given WebSocket from the active connections list.
         """
-        self.active_connections.remove(websocket)
+        del self.active_connections[user_id]
+        del ccat.ws_messages[user_id]
 
-    async def send_personal_message(self, message: str, websocket: WebSocket):
+    async def send_personal_message(self, message: str, user_id: str = "user"):
         """
         Send a personal message (in JSON format) to the specified WebSocket.
         """
-        await websocket.send_json(message)
+        await self.active_connections[user_id].send_json(message)
 
     async def broadcast(self, message: str):
         """
         Send a message to all active WebSocket connections.
         """
-        for connection in self.active_connections:
+        for connection in self.active_connections.values():
             await connection.send_json(message)
 
 
 manager = ConnectionManager()
 
 
-async def receive_message(websocket: WebSocket, ccat: object):
+async def receive_message(ccat: object, user_id: str = "user"):
     """
     Continuously receive messages from the WebSocket and forward them to the `ccat` object for processing.
     """
+    ws = manager.active_connections[user_id]
     while True:
-        user_message = await websocket.receive_json()
+        user_message = await ws.receive_json()
 
         # Run the `ccat` object's method in a threadpool since it might be a CPU-bound operation.
         cat_message = await run_in_threadpool(ccat, user_message)
 
         # Send the response message back to the user.
-        await manager.send_personal_message(cat_message, websocket)
+        await manager.send_personal_message(cat_message, ws)
 
 
-async def check_messages(websocket: WebSocket, ccat):
+async def check_messages(ccat, user_id: str = "user"):
     """
     Periodically check if there are any new notifications from the `ccat` instance and send them to the user.
     """
     while True:
 
         # extract from FIFO list websocket notification
-        notification = await ccat.ws_messages.get()
-        await manager.send_personal_message(notification, websocket)
+        notification = await ccat.ws_messages[user_id].get()
+        await manager.send_personal_message(notification, manager.active_connections[user_id])
 
 
 @router.websocket_route("/ws")
@@ -91,8 +92,8 @@ async def websocket_endpoint(websocket: WebSocket):
     try:
         # Process messages and check for notifications concurrently.
         await asyncio.gather(
-            receive_message(websocket, ccat),
-            check_messages(websocket, ccat)
+            receive_message(ccat),
+            check_messages(ccat)
         )
     except WebSocketDisconnect:
         # Handle the event where the user disconnects their WebSocket.
@@ -108,4 +109,39 @@ async def websocket_endpoint(websocket: WebSocket):
         }, websocket)
     finally:
         # Always ensure the WebSocket is removed from the manager, regardless of how the above block exits.
-        manager.disconnect(websocket)
+        manager.disconnect(ccat, websocket)
+
+
+@router.websocket_route("/ws/{user_id}")
+async def websocket_endpoint(websocket: WebSocket, user_id: str):
+    """
+    Endpoint to handle incoming WebSocket connections by user id.
+    """
+
+    # Retrieve the `ccat` instance from the application's state.
+    ccat = websocket.app.state.ccat
+
+    # Add the new WebSocket connection to the manager.
+    await manager.connect(websocket, user_id)
+
+    try:
+        # Process messages and check for notifications concurrently.
+        await asyncio.gather(
+            receive_message(ccat, user_id),
+            check_messages(ccat, user_id)
+        )
+    except WebSocketDisconnect:
+        # Handle the event where the user disconnects their WebSocket.
+        log.info("WebSocket connection closed")
+    except Exception as e:
+        # Log any unexpected errors and send an error message back to the user.
+        log.error(e)
+        traceback.print_exc()
+        await manager.send_personal_message({
+            "type": "error",
+            "name": type(e).__name__,
+            "description": str(e),
+        }, websocket)
+    finally:
+        # Always ensure the WebSocket is removed from the manager, regardless of how the above block exits.
+        manager.disconnect(ccat, websocket)

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -98,6 +98,11 @@ async def websocket_endpoint(websocket: WebSocket, user_id: Optional[str] = None
     # If no user id is specified, use "user" as the default.
     user_id = user_id or "user"
 
+    if user_id in manager.active_connections:
+        # If the user already has an active WebSocket connection, close it.
+        await manager.active_connections[user_id].close()
+        manager.disconnect(ccat, user_id)
+
     # Add the new WebSocket connection to the manager.
     await manager.connect(websocket, user_id)
 

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -31,14 +31,17 @@ class ConnectionManager:
         """
         Remove the given WebSocket from the active connections list.
         """
-        del self.active_connections[user_id]
-        del ccat.ws_messages[user_id]
+        if user_id in self.active_connections:
+            del self.active_connections[user_id]
+        if user_id in ccat.ws_messages:
+            del ccat.ws_messages[user_id]
 
     async def send_personal_message(self, message: str, user_id: str = "user"):
         """
         Send a personal message (in JSON format) to the specified WebSocket.
         """
-        await self.active_connections[user_id].send_json(message)
+        if user_id in self.active_connections:
+            await self.active_connections[user_id].send_json(message)
 
     async def broadcast(self, message: str):
         """

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -120,5 +120,5 @@ async def websocket_endpoint(websocket: WebSocket, user_id: Optional[str] = None
             "description": str(e),
         }, user_id)
     finally:
-        # Always ensure the WebSocket is removed from the manager, regardless of how the above block exits.
-        manager.disconnect(ccat, websocket)
+        # Remove the WebSocket from the manager when the user disconnects.
+        manager.disconnect(ccat, user_id)

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -3,9 +3,9 @@ import shutil
 
 
 # utility function to communicate with the cat via websocket
-def send_websocket_message(msg, client):
+def send_websocket_message(msg, client, user_id: str = "user"):
 
-    with client.websocket_connect("/ws") as websocket:
+    with client.websocket_connect(f"/ws/{user_id}") as websocket:
         
         # sed ws message
         websocket.send_json(msg)
@@ -24,11 +24,11 @@ def send_n_websocket_messages(num_messages, client):
         message = {
             "text": f"Red Queen {m}"
         }
-        res = send_websocket_message(message, client)
+        res = send_websocket_message(message, client, f"user_{m}")
         responses.append(res)
 
     return responses
-            
+
 
 def key_in_json(key, json):
     return key in json.keys()

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -3,13 +3,11 @@ import shutil
 
 
 # utility function to communicate with the cat via websocket
-def send_websocket_message(msg, client, user_id: str = "user"):
+def send_websocket_message(msg, client):
 
-    with client.websocket_connect(f"/ws/{user_id}") as websocket:
-        
+    with client.websocket_connect(f"/ws") as websocket:
         # sed ws message
         websocket.send_json(msg)
-
         # get reply
         reply = websocket.receive_json()
     
@@ -20,12 +18,17 @@ def send_websocket_message(msg, client, user_id: str = "user"):
 def send_n_websocket_messages(num_messages, client):
 
     responses = []
-    for m in range(num_messages):
-        message = {
-            "text": f"Red Queen {m}"
-        }
-        res = send_websocket_message(message, client, f"user_{m}")
-        responses.append(res)
+
+    with client.websocket_connect(f"/ws") as websocket:
+        for m in range(num_messages):
+            message = {
+                "text": f"Red Queen {m}"
+            }
+            # sed ws message
+            websocket.send_json(message)
+            # get reply
+            reply = websocket.receive_json()
+            responses.append(reply)
 
     return responses
 


### PR DESCRIPTION
# Description

With this PR, the WebSocket messages should be split for each user_id. When the user_id is not passed, it will default to "user".

This actually breaks token streaming.

Related to issue #488 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
