### PR TITLE
Moved path functions from `CheshireCat` to `utils`

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -9,6 +9,7 @@ from langchain.llms import Cohere, OpenAI, AzureOpenAI, HuggingFaceTextGenInfere
 from langchain.chat_models import ChatOpenAI, AzureChatOpenAI
 from langchain.base_language import BaseLanguageModel
 
+import cat.utils as utils
 from cat.log import log
 from cat.db import crud
 from cat.db.database import Database
@@ -127,7 +128,6 @@ class CheshireCat:
                 llm = llms.LLMDefaultConfig.get_llm_from_config({})
 
         return llm
-
 
     def get_language_embedder(self) -> embedders.EmbedderSettings:
         """Hook into the  embedder selection.
@@ -383,29 +383,6 @@ class CheshireCat:
                 )
             )    
 
-    def get_base_url(self):
-        """Allows the Cat expose the base url."""
-        secure = os.getenv('CORE_USE_SECURE_PROTOCOLS', '')
-        if secure != '':
-            secure = 's'
-        return f'http{secure}://{os.environ["CORE_HOST"]}:{os.environ["CORE_PORT"]}/'
-
-    def get_base_path(self):
-        """Allows the Cat expose the base path."""
-        return "cat/"
-
-    def get_plugin_path(self):
-        """Allows the Cat expose the plugins path."""
-        return os.path.join(self.get_base_path(), "plugins/")
-
-    def get_static_url(self):
-        """Allows the Cat expose the static server url."""
-        return self.get_base_url() + "static/"
-    
-    def get_static_path(self):
-        """Allows the Cat expose the static files path."""
-        return os.path.join(self.get_base_path(), "static/")
-
     def __call__(self, user_message_json):
         """Call the Cat instance.
 
@@ -520,3 +497,34 @@ class CheshireCat:
         final_output = self.mad_hatter.execute_hook("before_cat_sends_message", final_output)
 
         return final_output
+
+
+    # TODO: remove this method in a few versions, current version 1.2.0
+    def get_base_url():
+        """Allows the Cat expose the base url."""
+        log.warning("This method will be removed, import cat.utils tu use it instead.")
+        return utils.get_base_url()
+
+    # TODO: remove this method in a few versions, current version 1.2.0
+    def get_base_path():
+        """Allows the Cat expose the base path."""
+        log.warning("This method will be removed, import cat.utils tu use it instead.")
+        return utils.get_base_path()
+
+    # TODO: remove this method in a few versions, current version 1.2.0
+    def get_plugin_path():
+        """Allows the Cat expose the plugins path."""
+        log.warning("This method will be removed, import cat.utils tu use it instead.")
+        return utils.get_plugin_path()
+
+    # TODO: remove this method in a few versions, current version 1.2.0
+    def get_static_url():
+        """Allows the Cat expose the static server url."""
+        log.warning("This method will be removed, import cat.utils tu usit instead.")
+        return utils.get_static_url()
+
+    # TODO: remove this method in a few versions, current version 1.2.0
+    def get_static_path():
+        """Allows the Cat expose the static files path."""
+        log.warning("This method will be removed, import cat.utils tu usit instead.")
+        return utils.get_static_path()

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -4,6 +4,9 @@ import time
 import shutil
 import os
 import traceback
+
+import cat.utils as utils
+
 from copy import deepcopy
 
 from cat.log import log
@@ -33,14 +36,15 @@ class MadHatter:
 
         self.active_plugins = []
 
+        self.plugins_folder = utils.get_plugin_path()
+
         self.find_plugins()
 
     def install_plugin(self, package_plugin):
 
         # extract zip/tar file into plugin folder
-        plugins_folder = self.ccat.get_plugin_path()
         extractor = PluginExtractor(package_plugin)
-        plugin_path = extractor.extract(plugins_folder)
+        plugin_path = extractor.extract(self.plugins_folder)
 
         # remove zip after extraction
         os.remove(package_plugin)
@@ -82,10 +86,8 @@ class MadHatter:
         # plus the default core plugin s(where default hooks and tools are defined)
         core_plugin_folder = "cat/mad_hatter/core_plugin/"
 
-         # plugin folder is "cat/plugins/" in production, "tests/mocks/mock_plugin_folder/" during tests
-        plugins_folder = self.ccat.get_plugin_path()
-
-        all_plugin_folders = [core_plugin_folder] + glob.glob(f"{plugins_folder}*/")
+        # plugin folder is "cat/plugins/" in production, "tests/mocks/mock_plugin_folder/" during tests
+        all_plugin_folders = [core_plugin_folder] + glob.glob(f"{self.plugins_folder}*/")
 
         log.info("ACTIVE PLUGINS:")
         log.info(self.active_plugins)

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -1,5 +1,4 @@
 import glob
-import json
 import time
 import shutil
 import os

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -84,10 +84,6 @@ def get_plugin_path():
     """Allows the Cat expose the plugins path."""
     return os.path.join(get_base_path(), "plugins/")
 
-def get_test_plugin_path():
-    """Allows the Cat expose the plugins path."""
-    return "tests/mocks/mock_plugin_folder/"
-
 def get_static_url():
     """Allows the Cat expose the static server url."""
     return get_base_url() + "static/"

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -1,5 +1,5 @@
 """Various utiles used from the projects."""
-
+import os
 from datetime import timedelta
 
 
@@ -67,3 +67,31 @@ def verbal_timedelta(td: timedelta) -> str:
         return "{} ago".format(abs_delta)
     else:
         return "{} ago".format(abs_delta)
+
+
+def get_base_url():
+    """Allows the Cat expose the base url."""
+    secure = os.getenv('CORE_USE_SECURE_PROTOCOLS', '')
+    if secure != '':
+        secure = 's'
+    return f'http{secure}://{os.environ["CORE_HOST"]}:{os.environ["CORE_PORT"]}/'
+
+def get_base_path():
+    """Allows the Cat expose the base path."""
+    return "cat/"
+
+def get_plugin_path():
+    """Allows the Cat expose the plugins path."""
+    return os.path.join(get_base_path(), "plugins/")
+
+def get_test_plugin_path():
+    """Allows the Cat expose the plugins path."""
+    return "tests/mocks/mock_plugin_folder/"
+
+def get_static_url():
+    """Allows the Cat expose the static server url."""
+    return get_base_url() + "static/"
+
+def get_static_path():
+    """Allows the Cat expose the static files path."""
+    return os.path.join(get_base_path(), "static/")

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -13,7 +13,10 @@ from cat.db import models
 from cat.db.database import Database
 from cat.log import log
 
+import cat.utils as utils
+
 from cat.looking_glass.cheshire_cat import CheshireCat
+from cat.mad_hatter.mad_hatter import MadHatter
 from qdrant_client import QdrantClient
 from cat.memory.vector_memory import VectorMemory
 
@@ -46,10 +49,10 @@ def app(monkeypatch) -> Generator[FastAPI, Any, None]:
     Create a new setup on each test case, with new mocks for both Qdrant and TinyDB
     """
 
-    # Use mock plugin folder
-    def mock_plugin_folder(self, *args, **kwargs):
+    # Use mock utils plugin folder
+    def get_test_plugin_folder():
         return "tests/mocks/mock_plugin_folder/"
-    monkeypatch.setattr(CheshireCat, "get_plugin_path", mock_plugin_folder)
+    utils.get_plugin_path = get_test_plugin_folder
 
     # Use in memory vector db
     def mock_connect_to_vector_memory(self, *args, **kwargs):

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -8,15 +8,12 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from tinydb import Query
-from cat.db import models
+
 from cat.db.database import Database
 from cat.log import log
 
 import cat.utils as utils
 
-from cat.looking_glass.cheshire_cat import CheshireCat
-from cat.mad_hatter.mad_hatter import MadHatter
 from qdrant_client import QdrantClient
 from cat.memory.vector_memory import VectorMemory
 

--- a/core/tests/mad_hatter/test_mad_hatter.py
+++ b/core/tests/mad_hatter/test_mad_hatter.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import pytest
 from inspect import isfunction
 

--- a/core/tests/mad_hatter/test_mad_hatter.py
+++ b/core/tests/mad_hatter/test_mad_hatter.py
@@ -3,6 +3,8 @@ import shutil
 import pytest
 from inspect import isfunction
 
+import cat.utils as utils
+
 from cat.mad_hatter.mad_hatter import MadHatter, Plugin
 from cat.mad_hatter.decorators import CatHook, CatTool
 from cat.looking_glass.cheshire_cat import CheshireCat
@@ -69,7 +71,7 @@ def test_plugin_install(mad_hatter: MadHatter, plugin_is_flat):
 
     # archive extracted
     assert os.path.exists(
-        os.path.join(mad_hatter.ccat.get_plugin_path(), "mock_plugin")
+        os.path.join(utils.get_plugin_path(), "mock_plugin")
     )
 
     # plugins list updated
@@ -127,7 +129,7 @@ def test_plugin_uninstall(mad_hatter: MadHatter, plugin_is_flat):
 
     # directory removed
     assert not os.path.exists(
-        os.path.join(mad_hatter.ccat.get_plugin_path(), "mock_plugin")
+        os.path.join(utils.get_plugin_path(), "mock_plugin")
     )
 
     # plugins list updated


### PR DESCRIPTION
# Description

In this PR i moved the following function from the class `CheshireCat` to `utils.py`:
- `get_base_url`
- `get_base_path`
- `get_plugin_path`
- `get_static_url`
- `get_static_path`

For backward compatibility with plugins, the methods listed above are still present in `CheshireCat`, but if used a warning message will be shown in the console.

There are also fixes to the Mad Hatter for reading the plugins path using the functions moved to utils, and the fix to the mock plugins folder in the tests.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
