### PR TITLE
Add utility to get the path of the current plugin

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -501,30 +501,30 @@ class CheshireCat:
 
     # TODO: remove this method in a few versions, current version 1.2.0
     def get_base_url():
-        """Allows the Cat expose the base url."""
+        """Allows the Cat exposing the base url."""
         log.warning("This method will be removed, import cat.utils tu use it instead.")
         return utils.get_base_url()
 
     # TODO: remove this method in a few versions, current version 1.2.0
     def get_base_path():
-        """Allows the Cat expose the base path."""
+        """Allows the Cat exposing the base path."""
         log.warning("This method will be removed, import cat.utils tu use it instead.")
         return utils.get_base_path()
 
     # TODO: remove this method in a few versions, current version 1.2.0
-    def get_plugin_path():
-        """Allows the Cat expose the plugins path."""
+    def get_plugins_path():
+        """Allows the Cat exposing the plugins path."""
         log.warning("This method will be removed, import cat.utils tu use it instead.")
-        return utils.get_plugin_path()
+        return utils.get_plugins_path()
 
     # TODO: remove this method in a few versions, current version 1.2.0
     def get_static_url():
-        """Allows the Cat expose the static server url."""
+        """Allows the Cat exposing the static server url."""
         log.warning("This method will be removed, import cat.utils tu usit instead.")
         return utils.get_static_url()
 
     # TODO: remove this method in a few versions, current version 1.2.0
     def get_static_path():
-        """Allows the Cat expose the static files path."""
+        """Allows the Cat exposing the static files path."""
         log.warning("This method will be removed, import cat.utils tu usit instead.")
         return utils.get_static_path()

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -35,7 +35,7 @@ class MadHatter:
 
         self.active_plugins = []
 
-        self.plugins_folder = utils.get_plugin_path()
+        self.plugins_folder = utils.get_plugins_path()
 
         self.find_plugins()
 

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -1,9 +1,10 @@
 """Various utiles used from the projects."""
 import os
+import inspect
 from datetime import timedelta
 
 
-def to_camel_case(text :str ) -> str:
+def to_camel_case(text: str) -> str:
     """Format string to camel case.
 
     Takes a string of words separated by either hyphens or underscores and returns a string of words in camel case.
@@ -70,24 +71,46 @@ def verbal_timedelta(td: timedelta) -> str:
 
 
 def get_base_url():
-    """Allows the Cat expose the base url."""
+    """Allows exposing the base url."""
     secure = os.getenv('CORE_USE_SECURE_PROTOCOLS', '')
     if secure != '':
         secure = 's'
     return f'http{secure}://{os.environ["CORE_HOST"]}:{os.environ["CORE_PORT"]}/'
 
+
 def get_base_path():
-    """Allows the Cat expose the base path."""
+    """Allows exposing the base path."""
     return "cat/"
 
-def get_plugin_path():
-    """Allows the Cat expose the plugins path."""
+
+def get_plugins_path():
+    """Allows exposing the plugins' path."""
     return os.path.join(get_base_path(), "plugins/")
 
+
 def get_static_url():
-    """Allows the Cat expose the static server url."""
+    """Allows exposing the static server url."""
     return get_base_url() + "static/"
 
+
 def get_static_path():
-    """Allows the Cat expose the static files path."""
+    """Allows exposing the static files' path."""
     return os.path.join(get_base_path(), "static/")
+
+
+def get_current_plugin_path():
+    """Allows accessing the current plugin path."""
+    # Get the current execution frame of the calling module,
+    # then the previous frame in the call stack
+    frame = inspect.currentframe().f_back
+    # Get the module associated with the frame
+    module = inspect.getmodule(frame)
+    # Get the absolute and then relative path of the calling module's file
+    abs_path = inspect.getabsfile(module)
+    rel_path = os.path.relpath(abs_path)
+    # Replace the root and get only the current plugin folder
+    plugin_suffix = rel_path.replace(get_plugins_path(), "")
+    # Plugin's folder
+    folder_name = plugin_suffix.split("/")[0]
+    # Get current plugin's folder
+    return os.path.join(get_plugins_path(), folder_name)

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -49,7 +49,7 @@ def app(monkeypatch) -> Generator[FastAPI, Any, None]:
     # Use mock utils plugin folder
     def get_test_plugin_folder():
         return "tests/mocks/mock_plugin_folder/"
-    utils.get_plugin_path = get_test_plugin_folder
+    utils.get_plugins_path = get_test_plugin_folder
 
     # Use in memory vector db
     def mock_connect_to_vector_memory(self, *args, **kwargs):

--- a/core/tests/mad_hatter/test_mad_hatter.py
+++ b/core/tests/mad_hatter/test_mad_hatter.py
@@ -70,7 +70,7 @@ def test_plugin_install(mad_hatter: MadHatter, plugin_is_flat):
 
     # archive extracted
     assert os.path.exists(
-        os.path.join(utils.get_plugin_path(), "mock_plugin")
+        os.path.join(utils.get_plugins_path(), "mock_plugin")
     )
 
     # plugins list updated
@@ -128,7 +128,7 @@ def test_plugin_uninstall(mad_hatter: MadHatter, plugin_is_flat):
 
     # directory removed
     assert not os.path.exists(
-        os.path.join(utils.get_plugin_path(), "mock_plugin")
+        os.path.join(utils.get_plugins_path(), "mock_plugin")
     )
 
     # plugins list updated


### PR DESCRIPTION
# Description

This PR adds a utility function to provide developers a method to get their plugin path avoiding hard-coded paths. 
Additionally, it updates tests and corrects few typos.

Related to issue #482 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
