### PR TITLE
FIX: docker build

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -36,6 +36,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      # Uses the `docker/setup-qemu-action@v3`
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Uses the `docker/setup-buildx-action@v3`
+      - name: Set up docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       # Uses the `docker/login-action`
       # action to log in to the Container registry using the account and password that will publish the packages.
       # Once published, the packages are scoped to the account defined here.

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.10.11-slim-bullseye
 ### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
 RUN mkdir -p /app && mkdir -p /admin
 COPY ./pyproject.toml /app/pyproject.toml
-COPY ./cat/plugins /app/cat/plugins
+COPY ./cat /app/cat
 COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py
 
 ### SYSTEM SETUP ###


### PR DESCRIPTION
# Description

## Issue

The pre-built docker image contains only `cat/plugins` folder instead all the core. This cause the current pre-built image by github action to be incomplete and to fail with error `/usr/local/bin/python: No module named cat.main`.

## Solution

Change COPY command of the Dockerfile to include the whole `cat` folder and modify the docker-compose.yml accordingly to use the generated image and to not bind mount `/core` anymore.

## Extra

Edit github action to support multi-platform build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
