### PR TITLE
Fix hooks before_cat_recall inverted defaults

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -307,8 +307,8 @@ class CheshireCat():
         # hooks to change recall configs for each memory
         recall_configs = [
             self.mad_hatter.execute_hook("before_cat_recalls_episodic_memories", default_episodic_recall_config),
-            self.mad_hatter.execute_hook("before_cat_recalls_declarative_memories", default_procedural_recall_config),
-            self.mad_hatter.execute_hook("before_cat_recalls_procedural_memories", default_declarative_recall_config)
+            self.mad_hatter.execute_hook("before_cat_recalls_declarative_memories", default_declarative_recall_config),
+            self.mad_hatter.execute_hook("before_cat_recalls_procedural_memories", default_procedural_recall_config)
         ]
 
         memory_types = self.memory.vectors.collections.keys()


### PR DESCRIPTION
Default configs passed to hooks before_cat_recalls_declarative_memories and before_cat_recalls_procedural_memories are inverted, fixed

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
