### PR TITLE
Initialize the CheshireCat only once

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -80,9 +80,6 @@ class CheshireCat():
         # allows plugins to do something after the cat bootstrap is complete
         self.mad_hatter.execute_hook("after_cat_bootstrap")
 
-        # queue of cat messages not directly related to last user input
-        # i.e. finished uploading a file
-        self.ws_messages: Dict[str, asyncio.Queue] = {}
 
     def load_natural_language(self):
         """Load Natural Language related objects.

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -47,6 +47,7 @@ class CheshireCat():
     def __new__(cls):
         if not cls._instance:
             cls._instance = super().__new__(cls)
+            cls._instance.__initialized = False
         return cls._instance
 
     def __init__(self):
@@ -54,6 +55,9 @@ class CheshireCat():
 
         At init time the Cat executes the bootstrap.
         """
+
+        if self.__initialized:
+            return
 
         # bootstrap the cat!
         # reinstantiate MadHatter (reloads all plugins' hooks and tools)
@@ -80,6 +84,7 @@ class CheshireCat():
         # allows plugins to do something after the cat bootstrap is complete
         self.mad_hatter.execute_hook("after_cat_bootstrap")
 
+        self.__initialized = True
 
     def load_natural_language(self):
         """Load Natural Language related objects.

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -56,6 +56,7 @@ class CheshireCat():
         At init time the Cat executes the bootstrap.
         """
 
+        # If the CheshireCat is already instantiated skip the initialization
         if self.__initialized:
             return
 


### PR DESCRIPTION
# Description

This PR causes Cheshire Cat's `__init__` method to be called only once so as not to reinitialize the cat instance

Related to issue #443

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
