### PR TITLE
Dev/binary quantization

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y update && apt-get install -y curl build-essential fastjar libmagi
 
 ### ADMIN (static build) ###
 WORKDIR /admin
-RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
+RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/release.zip | jar -xv
 
 ### INSTALL PYTHON DEPENDENCIES (Core and Plugins) ###
 WORKDIR /app

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -10,7 +10,7 @@ from qdrant_client.qdrant_remote import QdrantRemote
 from langchain.embeddings.base import Embeddings
 from langchain.vectorstores import Qdrant
 from qdrant_client.http.models import (Distance, VectorParams,  SearchParams, 
-                                    BinaryQuantization, BinaryQuantizationConfig, ScalarType, QuantizationSearchParams, 
+                                    BinaryQuantization, BinaryQuantizationConfig, QuantizationSearchParams, 
                                     CreateAliasOperation, CreateAlias, OptimizersConfigDiff)
 
 
@@ -169,7 +169,6 @@ class VectorMemoryCollection(Qdrant):
                     always_ram=True
                 )
             ),
-            #shard_number=3,
         )
         
         self.client.update_collection_aliases(

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -160,12 +160,12 @@ class VectorMemoryCollection(Qdrant):
             collection_name=self.collection_name,
             vectors_config=VectorParams(
                 size=self.embedder_size, distance=Distance.COSINE, on_disk=True,),
-            optimizers_config=models.OptimizersConfigDiff(
+            optimizers_config=OptimizersConfigDiff(
               default_segment_number=5,
               indexing_threshold=0,
             ),
             quantization_config=BinaryQuantization(
-                scalar=BinaryQuantizationConfig(
+                binary=BinaryQuantizationConfig(
                     always_ram=True
                 )
             ),

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -10,7 +10,7 @@ from qdrant_client.qdrant_remote import QdrantRemote
 from langchain.embeddings.base import Embeddings
 from langchain.vectorstores import Qdrant
 from qdrant_client.http.models import (Distance, VectorParams,  SearchParams, 
-                                    ScalarQuantization, ScalarQuantizationConfig, ScalarType, QuantizationSearchParams, 
+                                    BinaryQuantization, BinaryQuantizationConfig, ScalarType, QuantizationSearchParams, 
                                     CreateAliasOperation, CreateAlias, OptimizersConfigDiff)
 
 
@@ -159,13 +159,14 @@ class VectorMemoryCollection(Qdrant):
         self.client.recreate_collection(
             collection_name=self.collection_name,
             vectors_config=VectorParams(
-                size=self.embedder_size, distance=Distance.COSINE),
-            #optimizers_config=OptimizersConfigDiff(memmap_threshold=20000),
-            quantization_config=ScalarQuantization(
-                scalar=ScalarQuantizationConfig(
-                    type=ScalarType.INT8,
-                    quantile=0.75,
-                    always_ram=False
+                size=self.embedder_size, distance=Distance.COSINE, on_disk=True,),
+            optimizers_config=models.OptimizersConfigDiff(
+              default_segment_number=5,
+              indexing_threshold=0,
+            ),
+            quantization_config=BinaryQuantization(
+                scalar=BinaryQuantizationConfig(
+                    always_ram=True
                 )
             ),
             #shard_number=3,
@@ -223,7 +224,7 @@ class VectorMemoryCollection(Qdrant):
                 quantization=QuantizationSearchParams(
                     ignore=False,
                     rescore=True,
-                    # oversampling=1.5 # Available as of v1.3.0
+                    oversampling=2.0,
                 )
             )
         )


### PR DESCRIPTION
# Description

Moved from ScalarQuantization to BinaryQuantization. Binary quantization is 40x faster and will reduce the memory consumption as described in [Qdrant article](https://qdrant.tech/articles/binary-quantization/)

Related to issue #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
