### PR TITLE
add get_current_plugin_settings

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -10,6 +10,7 @@ from cat.db import crud
 from cat.db.models import Setting
 from cat.mad_hatter.plugin_extractor import PluginExtractor
 from cat.mad_hatter.plugin import Plugin
+import inspect
 
 # This class is responsible for plugins functionality:
 # - loading
@@ -290,3 +291,10 @@ class MadHatter:
 
         # tea_cup has passed through all hooks. Return final output
         return tea_cup
+
+    def get_current_plugin_settings(self):
+        calling_frame = inspect.currentframe().f_back
+        path = utils.get_current_plugin_path(calling_frame)
+        name = path.split("/")[-1]
+
+        return self.plugins[name].load_settings()

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -100,13 +100,13 @@ def get_static_path():
     return os.path.join(get_base_path(), "static/")
 
 
-def get_current_plugin_path():
-    """Allows accessing the current plugin path."""
-    # Get the current execution frame of the calling module,
-    # then the previous frame in the call stack
-    frame = inspect.currentframe().f_back
+def get_current_plugin_path(calling_frame=None):
+    if calling_frame is None:
+        # If calling_frame is not provided, use the current frame
+        calling_frame = inspect.currentframe().f_back
+
     # Get the module associated with the frame
-    module = inspect.getmodule(frame)
+    module = inspect.getmodule(calling_frame)
     # Get the absolute and then relative path of the calling module's file
     abs_path = inspect.getabsfile(module)
     rel_path = os.path.relpath(abs_path)


### PR DESCRIPTION
# Description

I created a new get_current_plugin_settings method in MadHatter to get the current plugin settings

Related to issue #([482](https://github.com/cheshire-cat-ai/core/issues/482))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
