### PR TITLE
FIX: crash loop on faulty embedder settings

### DIFF
--- a/core/cat/db/crud.py
+++ b/core/cat/db/crud.py
@@ -51,6 +51,11 @@ def delete_setting_by_id(setting_id: str) -> None:
     get_db().remove(query.setting_id == setting_id)    
 
 
+def delete_settings_by_category(category: str) -> None:
+    query = Query()
+    get_db().remove(query.category == category)
+
+
 def update_setting_by_id(payload: models.Setting) -> Dict:
     
     query = Query()

--- a/core/cat/routes/embedder.py
+++ b/core/cat/routes/embedder.py
@@ -123,7 +123,18 @@ def upsert_embedder_setting(
     # reload llm and embedder of the cat
     ccat.load_natural_language()
     # crete new collections (different embedder!)
-    ccat.load_memory()
+    try:
+        ccat.load_memory()
+    except Exception as e:
+        log.error(e)
+        crud.delete_settings_by_category(category=EMBEDDER_SELECTED_CATEGORY)
+        crud.delete_settings_by_category(category=EMBEDDER_CATEGORY)
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": str(e)
+            }
+        )
     # recreate tools embeddings
     ccat.mad_hatter.find_plugins()
     ccat.mad_hatter.embed_tools()


### PR DESCRIPTION
# Description

- crud.py: new method delete_settings_by_category
- embedder.py: manage exception on embedder settings update, in case of error, last settings are deleted

Related to issue #461

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
