### PR TITLE
FIX: handling of very long chat messages

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -26,6 +26,7 @@ from cat.factory.custom_llm import CustomOpenAI
 
 
 MSG_TYPES = Literal["notification", "chat", "error", "chat_token"]
+MAX_TEXT_INPUT = 500
 
 # main class
 class CheshireCat():
@@ -431,6 +432,19 @@ class CheshireCat():
 
         # hook to modify/enrich user input
         user_message_json = self.mad_hatter.execute_hook("before_cat_reads_message", user_message_json)
+
+        # split text after MAX_TEXT_INPUT tokens, on a whitespace, if any, and send it to declarative memory
+        if len(user_message_json["text"]) > MAX_TEXT_INPUT:
+            index = MAX_TEXT_INPUT
+            char = user_message_json["text"][index]
+            while not char.isspace() and index > 0:
+                index -= 1
+                char = user_message_json["text"][index]
+            if index <= 0:
+                index = MAX_TEXT_INPUT
+            user_message_json["text"], to_declarative_memory = user_message_json["text"][:index], user_message_json["text"][index:]
+            docs = self.rabbit_hole.string_to_docs(to_declarative_memory, content_type="text/plain")
+            self.rabbit_hole.store_documents(docs=docs, source="")
 
         # store last message in working memory
         user_working_memory["user_message_json"] = user_message_json

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -213,7 +213,47 @@ class RabbitHole:
                     file_bytes = f.read()
         else:
             raise ValueError(f"{type(file)} is not a valid type.")
+        return self.string_to_docs(
+            file_bytes,
+            source,
+            content_type,
+            chunk_size,
+            chunk_overlap
+        )
 
+    def string_to_docs(
+            self,
+            file_bytes: str,
+            source: str = None,
+            content_type: str = "text/plain",
+            chunk_size: int = 400,
+            chunk_overlap: int = 100
+        ) -> List[Document]:
+        """Convert string to Langchain `Document`.
+
+        Takes a string, converts it to langchain `Document`.
+        Hence, loads it in memory and splits it in overlapped chunks of text.
+
+        Parameters
+        ----------
+        file_bytes : str
+            The string to be converted.
+        source: str
+            Source filename.
+        content_type:
+            Mimetype of content.
+        chunk_size : int
+            Number of characters in each document chunk.
+        chunk_overlap : int
+            Number of overlapping characters between consecutive chunks.
+        send_message: bool
+            If true will send parsing message information to frontend.
+
+        Returns
+        -------
+        docs : List[Document]
+            List of Langchain `Document` of chunked text.
+        """
         # Load the bytes in the Blob schema
         blob = Blob(data=file_bytes,
                     mimetype=content_type,


### PR DESCRIPTION
# Description

## Handle of very long chat messages
The following files were changed:
- cheshire_cat.py: input message is split at MAX_TEXT_INPUT tokens saving what exceeds in declarative memory
- rabbit_hole.py: new method string_to_docs to just convert strings in documents

relates to issue #334

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
