### PR TITLE
Speed up build plugins

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,11 +1,6 @@
 
 FROM python:3.10.11-slim-bullseye
 
-### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
-COPY ./pyproject.toml /app/pyproject.toml
-COPY ./cat /app/cat
-COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py
-
 ### SYSTEM SETUP ###
 RUN apt-get -y update && apt-get install -y curl build-essential fastjar libmagic-mgc libmagic1 mime-support && \
     apt-get clean && \
@@ -15,12 +10,21 @@ RUN apt-get -y update && apt-get install -y curl build-essential fastjar libmagi
 WORKDIR /admin
 RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
 
-### INSTALL PYTHON DEPENDENCIES (Core and Plugins) ###
+### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
+COPY ./pyproject.toml /app/pyproject.toml
+
+### INSTALL PYTHON DEPENDENCIES (Core) ###
 WORKDIR /app
 RUN pip install -U pip && \
     pip install --no-cache-dir . &&\
-    python3 -c "import nltk; nltk.download('punkt');nltk.download('averaged_perceptron_tagger')" &&\
-    python3 install_plugin_dependencies.py
+    python3 -c "import nltk; nltk.download('punkt');nltk.download('averaged_perceptron_tagger')"
+
+### COPY PLUGINS ###
+COPY ./cat/plugins /app/cat/plugins
+
+### INSTALL PYTHON DEPENDENCIES (Plugins) ###
+COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py
+RUN python3 install_plugin_dependencies.py
 
 ### FINISH ###
 CMD python3 -m cat.main

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -2,7 +2,6 @@
 FROM python:3.10.11-slim-bullseye
 
 ### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
-RUN mkdir -p /app && mkdir -p /admin
 COPY ./pyproject.toml /app/pyproject.toml
 COPY ./cat /app/cat
 COPY ./install_plugin_dependencies.py /app/install_plugin_dependencies.py


### PR DESCRIPTION
# Description

- Removed mkdir of folders

The WORKDIR command already create the folder if missing

- Speed up build time when only plugins requirements installation

The dev define a new package in the requirements file.
The dev run the build with `docker compose build`.
The build recreate all the layers.
If the layer is the same, docker keep it, when a layer change, docker create the layer and all the layer after it.

Moved the apt-get commands before the others steps.
Moved the commands to copy of plugins and installation of plugins dependencies as last commands.
In this way, when a dev change the requirements file and do `docker compose build`, only the `COPY PLUGINS` and `INSTALL PYTHON DEPENDENCIES (Plugins)` are done, no time spent to do apt-get anymore.

Not related to issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
