### PR TITLE
Fix tests giga refactor

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -83,4 +83,5 @@ def client(app: FastAPI, monkeypatch) -> Generator[TestClient, Any, None]:
     """
     
     with TestClient(app) as client:
+        app.state.ccat.__init__()
         yield client


### PR DESCRIPTION
# Description
Fix failed tests when using @singleton with CheshireCat class.

Reason of the problem:
When the singleton was manually handled in `__new__`, `__init__` was called each time.
With the decorator, `__init__` is called only the first time.

Fix:
Forced the call to `__init__` of the cat instance

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
