### PR TITLE
Add event on plugin de-/activation

### DIFF
--- a/core/cat/mad_hatter/core_plugin/settings.py
+++ b/core/cat/mad_hatter/core_plugin/settings.py
@@ -78,3 +78,33 @@ def save_settings(settings):
 
     # In core_plugin we do nothing (for now).
     return {}
+
+
+@plugin
+def activated(plugin_id):
+    """
+
+    Parameters
+    ----------
+    plugin_id
+
+    Returns
+    -------
+
+    """
+    return None
+
+
+@plugin
+def deactivated(plugin_id):
+    """
+
+    Parameters
+    ----------
+    plugin_id
+
+    Returns
+    -------
+
+    """
+    return None

--- a/core/cat/mad_hatter/core_plugin/settings.py
+++ b/core/cat/mad_hatter/core_plugin/settings.py
@@ -81,30 +81,24 @@ def save_settings(settings):
 
 
 @plugin
-def activated(plugin_id):
-    """
+def activated(plugin):
+    """This method allows executing custom code right after a plugin is activated.
 
     Parameters
     ----------
-    plugin_id
-
-    Returns
-    -------
-
+    plugin
+        Plugin: Cat object representing the plugin instance in memory.
     """
     return None
 
 
 @plugin
-def deactivated(plugin_id):
-    """
+def deactivated(plugin):
+    """This method allows executing custom code right after a plugin is deactivated.
 
     Parameters
     ----------
-    plugin_id
-
-    Returns
-    -------
-
+    plugin
+        Plugin: Cat object representing the plugin instance in memory.
     """
     return None

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -186,7 +186,7 @@ class MadHatter:
                 # otherwise the hook will not be available in _plugin_overrides anymore
                 for hook in self.plugins[plugin_id]._plugin_overrides:
                     if hook.name == "deactivated":
-                        hook.function(plugin_id)
+                        hook.function(self.plugins[plugin_id])
 
                 # Deactivate the plugin
                 self.plugins[plugin_id].deactivate()
@@ -203,7 +203,7 @@ class MadHatter:
                 # otherwise the hook will still not be available in _plugin_overrides
                 for hook in self.plugins[plugin_id]._plugin_overrides:
                     if hook.name == "activated":
-                        hook.function(plugin_id)
+                        hook.function(self.plugins[plugin_id])
 
                 # Add the plugin in the list of active plugins
                 self.active_plugins.append(plugin_id)

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -180,14 +180,31 @@ class MadHatter:
             # update list of active plugins
             if plugin_is_active:
                 log.warning(f"Toggle plugin {plugin_id}: Deactivate")
+
+                # Execute hook on plugin deactivation
+                # Deactivation hook must happen before actual deactivation,
+                # otherwise the hook will not be available in _plugin_overrides anymore
+                for hook in self.plugins[plugin_id]._plugin_overrides:
+                    if hook.name == "deactivated":
+                        hook.function(plugin_id)
+
                 # Deactivate the plugin
                 self.plugins[plugin_id].deactivate()
                 # Remove the plugin from the list of active plugins
                 self.active_plugins.remove(plugin_id)
             else:
                 log.warning(f"Toggle plugin {plugin_id}: Activate")
+
                 # Activate the plugin
                 self.plugins[plugin_id].activate()
+
+                # Execute hook on plugin activation
+                # Activation hook must happen before actual activation,
+                # otherwise the hook will still not be available in _plugin_overrides
+                for hook in self.plugins[plugin_id]._plugin_overrides:
+                    if hook.name == "activated":
+                        hook.function(plugin_id)
+
                 # Add the plugin in the list of active plugins
                 self.active_plugins.append(plugin_id)
 


### PR DESCRIPTION
# Description

This PR adds two events (`@plugin` hooks) in the `MadHatter` [toggle](https://github.com/cheshire-cat-ai/core/blob/e01819c314bf003f29a6a6f21e630e7c005ff66a/core/cat/mad_hatter/mad_hatter.py#L218) to execute custom code.

Related to issue #442 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
