### PR TITLE
add: custom message for plugin errors

### DIFF
--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from cat.mad_hatter.decorators import CatTool, CatHook, CatPluginOverride
 from cat.utils import to_camel_case
 from cat.log import log
-
+from cat import utils
 
 # Empty class to represent basic plugin Settings model
 class PluginSettingsModel(BaseModel):
@@ -131,6 +131,8 @@ class Plugin:
             except Exception as e:
                 log.error(f"Unable to load plugin {self._id} settings")
                 log.error(e)
+                log.warning(utils.plugin_specific_error_message(self.manifest["name"], self.manifest["plugin_url"]))
+                traceback.print_exc()
                 raise e
         # settings.json does not exist # TODO: may be buggy or there is a better way via json_schema
         #else:
@@ -166,6 +168,8 @@ class Plugin:
                 json.dump(updated_settings, json_file, indent=4)
         except Exception:
             log.error(f"Unable to save plugin {self._id} settings")
+            log.warning(utils.plugin_specific_error_message(self.manifest["name"], self.manifest["plugin_url"]))
+            traceback.print_exc()
             return {}
     
         return updated_settings
@@ -226,6 +230,7 @@ class Plugin:
                 plugin_overrides += getmembers(plugin_module, self._is_cat_plugin_override)
             except Exception as e:
                 log.error(f"Error in {py_filename}: {str(e)}")
+                log.warning(utils.plugin_specific_error_message(self.manifest["name"], self.manifest["plugin_url"]))
                 traceback.print_exc()
                 raise Exception(f"Unable to load the plugin {self._id}") 
 

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -114,6 +114,9 @@ HOW TO FIX: go to your OpenAI accont and add a credit card"""
 
     return error_description
 
+def plugin_specific_error_message(name, url):
+    return """To resolve any problem related to {} plugin,
+contact the creator using github issue at the link {}""".format(name, url)
 
 # This is our masterwork during tea time
 class singleton:


### PR DESCRIPTION
## Description

A custom warning message is shown in case an error occurs during plugin operations.
Printing stack trace with the error.

relates to issue #602

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
