### PR TITLE
Fix hardcoded content type for uploading links

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -217,9 +217,6 @@ class RabbitHole:
                 except HTTPError as e:
                     log.error(e)
             else:
-
-                # Get mime type from file extension and source
-                content_type = mimetypes.guess_type(file)[0]
                 source = os.path.basename(file)
 
                 # Get file bytes

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -200,10 +200,11 @@ class RabbitHole:
             # Check if string file is a string or url
             parsed_file = urlparse(file)
             is_url = all([parsed_file.scheme, parsed_file.netloc])
+            content_type = mimetypes.guess_type(file)[0]
+            if content_type is None:
+                content_type = "text/html"
 
             if is_url:
-                # Define mime type and source of url
-                content_type = "text/html"
                 source = file
 
                 # Make a request with a fake browser name


### PR DESCRIPTION
# Description

Since there was a hardcoded `Content-Type` when a file was passed as a URL, this PR fixes this behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
