### PR TITLE
Update Cohere SDK

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "qdrant_client==1.6.9",
     "langchain==0.0.336",
     "openai==0.27.5",
-    "cohere==4.0.4",
+    "cohere==4.39",
     "huggingface-hub==0.13.2",
     "beautifulsoup4==4.12.0",
     "pdfminer.six==20221105",


### PR DESCRIPTION
# Description

The PR updates Cohere to the latest version that supports `embed-v3` which expects the `input_type` parameter.

Related to issue #626 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
