### PR TITLE
Feature/add gemini support

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -287,7 +287,7 @@ def get_allowed_language_models():
         LLMAzureOpenAIConfig,
         LLMAzureChatOpenAIConfig,
         LLMOllamaConfig,
-        LLMGeminiChatConfig
+        LLMGeminiChatConfig,
     ]
     
     mad_hatter_instance = MadHatter()

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -241,6 +241,19 @@ class LLMOllamaConfig(LLMSettings):
     )
 
 class LLMGeminiChatConfig(LLMSettings):
+    """Configuration for the Gemini large language model (LLM).
+
+    This class inherits from the `LLMSettings` class and provides default values for the following attributes:
+
+    * `google_api_key`: The Google API key used to access the Google Natural Language Processing (NLP) API.
+    * `model`: The name of the LLM model to use. In this case, it is set to "gemini".
+    * `temperature`: The temperature of the model, which controls the creativity and variety of the generated responses. 
+    * `top_p`: The top-p truncation value, which controls the probability of the generated words. 
+    * `top_k`: The top-k truncation value, which controls the number of candidate words to consider during generation. 
+    * `max_output_tokens`: The maximum number of tokens to generate in a single response.
+
+    The `LLMGeminiChatConfig` class is used to create an instance of the Gemini LLM model, which can be used to generate text in natural language.
+    """
     google_api_key: str 
     model: str = "gemini"
     temperature: float =  0.1

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -2,6 +2,7 @@ import langchain
 from langchain.chat_models import ChatOpenAI, AzureChatOpenAI
 from langchain.llms import OpenAI, AzureOpenAI
 from langchain.llms.ollama import Ollama
+from langchain_google_genai import ChatGoogleGenerativeAI
 
 from typing import Dict, List, Type
 import json
@@ -239,6 +240,25 @@ class LLMOllamaConfig(LLMSettings):
         }
     )
 
+class LLMGeminiChatConfig(LLMSettings):
+    google_api_key: str 
+    model: str = "gemini"
+    temperature: float =  0.1
+    top_p: int = 1
+    top_k: int =  1
+    max_output_tokens: int = 29000
+
+    _pyclass: Type = ChatGoogleGenerativeAI
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "humanReadableName": "Gemini",
+            "description": "Configuration for Gemini",
+            "link": "https://deepmind.google/technologies/gemini",
+        }
+    )
+
+
 
 def get_allowed_language_models():
     
@@ -253,7 +273,8 @@ def get_allowed_language_models():
         LLMHuggingFaceTextGenInferenceConfig,
         LLMAzureOpenAIConfig,
         LLMAzureChatOpenAIConfig,
-        LLMOllamaConfig
+        LLMOllamaConfig,
+        LLMGeminiChatConfig
     ]
     
     mad_hatter_instance = MadHatter()

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pandas==1.5.3",
     "scikit-learn==1.2.1",
     "qdrant_client==1.6.9",
-    "langchain==0.0.336",
+    "langchain==0.0.350",
     "openai==0.27.5",
     "cohere==4.39",
     "huggingface-hub==0.13.2",
@@ -26,7 +26,6 @@ dependencies = [
     "tomli",
     "loguru==0.7.0",
     "anthropic==0.2.9",
-    "google-generativeai==0.1.0rc3",
     "gunicorn==20.1.0",
     "uvicorn[standard]==0.20.0",
     "text_generation==0.6.1",
@@ -38,7 +37,8 @@ dependencies = [
     "pylint-actions",
     "pytest",
     "httpx",
-    "fastembed==0.1.1"
+    "fastembed==0.1.1",
+    "langchain-google-genai"
 ]
 
 [tool.coverage.run]

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pytest",
     "httpx",
     "fastembed==0.1.1",
-    "langchain-google-genai"
+    "langchain-google-genai",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

This change has been done to add a Google Gemini Adapter to the cat. It is now possible to get an API key from [Google AI for developers](https://ai.google.dev/) and use the Gemini model inside the cat. To do so, for now, it is necessary to use a VPN to connect since Google AI platform is not yet released in Europe.

Related to issue #629

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
