### PR TITLE
Creation of `settings.json` with default values

### DIFF
--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -224,8 +224,8 @@ async def get_plugins_settings(request: Request) -> Dict:
                 "schema": plugin_schema
             })
         except Exception as e:
-            log.error(f"Error loading {plugin} settings: {e}")
-
+            log.error(f"Error loading {plugin} settings. The result will not contain the settings for this plugin. Error details: {e}")
+    
     return {
         "settings": settings,
     }
@@ -244,9 +244,15 @@ async def get_plugin_settings(request: Request, plugin_id: str) -> Dict:
             detail = { "error": "Plugin not found" }
         )
 
-    # plugins are managed by the MadHatter class
-    settings = ccat.mad_hatter.plugins[plugin_id].load_settings()
-    schema = ccat.mad_hatter.plugins[plugin_id].settings_schema()
+    try:
+        settings = ccat.mad_hatter.plugins[plugin_id].load_settings()
+        schema = ccat.mad_hatter.plugins[plugin_id].settings_schema()
+    except Exception as e:
+        raise HTTPException(
+            status_code = 500,
+            detail = { "error": e }
+        )
+    
     if schema['properties'] == {}:
         schema = {}
 

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -223,8 +223,8 @@ async def get_plugins_settings(request: Request) -> Dict:
                 "value": plugin_settings,
                 "schema": plugin_schema
             })
-        except:
-            log.error(f"Error loading {plugin} settings")
+        except Exception as e:
+            log.error(f"Error loading {plugin} settings: {e}")
 
     return {
         "settings": settings,

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -28,6 +28,7 @@ def test_create_plugin_wrong_folder():
         
     assert f"Cannot create" in str(e.value)
 
+
 def test_create_plugin_empty_folder():
 
     path = "tests/mocks/empty_folder"
@@ -63,7 +64,7 @@ def test_activate_plugin(plugin):
     # activate it
     plugin.activate()
 
-    assert plugin.active == True
+    assert plugin.active is True
 
     # hooks
     assert len(plugin.hooks) == 2
@@ -82,7 +83,7 @@ def test_activate_plugin(plugin):
     assert tool.name == "mock_tool"
     assert "mock_tool" in tool.description
     assert isfunction(tool.func)
-    assert tool.return_direct == True
+    assert tool.return_direct is True
 
 
 def test_deactivate_plugin(plugin):
@@ -93,7 +94,7 @@ def test_deactivate_plugin(plugin):
     # deactivate it
     plugin.deactivate()
 
-    assert plugin.active == False
+    assert plugin.active is False
     
     # hooks and tools
     assert len(plugin.hooks) == 0
@@ -103,7 +104,7 @@ def test_deactivate_plugin(plugin):
 def test_settings_schema(plugin):
 
     settings_schema = plugin.settings_schema()
-    assert type(settings_schema) == dict
+    assert isinstance(settings_schema, dict)
     assert settings_schema["properties"] == {}
     assert settings_schema["title"] == "PluginSettingsModel"
     assert settings_schema['type'] == 'object'


### PR DESCRIPTION
# Description

This PR introduces the creation of the `settings.json` file on plugin activation and settings loading if the file does not exist.
The file will be created only if the settings model have a default value for each field.

Related to issue #454

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
