### PR TITLE
[ISSUE-633] Fixed documentation generation conflict

### DIFF
--- a/core/cat/mad_hatter/decorators/__init__.py
+++ b/core/cat/mad_hatter/decorators/__init__.py
@@ -1,3 +1,3 @@
-from cat.mad_hatter.decorators.hook import CatHook, hook
 from cat.mad_hatter.decorators.tool import CatTool, tool
-from cat.mad_hatter.decorators.plugin import CatPluginOverride, plugin
+from cat.mad_hatter.decorators.hook import CatHook, hook
+from cat.mad_hatter.decorators.plugin_decorator import CatPluginDecorator, plugin

--- a/core/cat/mad_hatter/decorators/plugin_decorator.py
+++ b/core/cat/mad_hatter/decorators/plugin_decorator.py
@@ -1,6 +1,6 @@
 
 # class to represent a @plugin override
-class CatPluginOverride:
+class CatPluginDecorator:
 
     def __init__(self, function):
         
@@ -10,5 +10,5 @@ class CatPluginOverride:
 # @plugin decorator. Any function in a plugin decorated by @plugin and named properly (among list of available overrides)
 #   is used to override plugin behaviour. These are not hooks because they are not piped, they are specific for every plugin
 def plugin(func):
-    return CatPluginOverride(func)
+    return CatPluginDecorator(func)
     

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -8,7 +8,7 @@ from typing import Dict
 from inspect import getmembers
 from pydantic import BaseModel, ValidationError
 
-from cat.mad_hatter.decorators import CatTool, CatHook, CatPluginOverride
+from cat.mad_hatter.decorators import CatTool, CatHook, CatPluginDecorator
 from cat.utils import to_camel_case
 from cat.log import log
 from cat import utils
@@ -297,10 +297,10 @@ class Plugin:
         return isinstance(obj, CatTool)
     
     # a plugin override function has to be decorated with @plugin
-    # (which returns an instance of CatPluginOverride)
+    # (which returns an instance of CatPluginDecorator)
     @staticmethod
     def _is_cat_plugin_override(obj):
-        return isinstance(obj, CatPluginOverride)
+        return isinstance(obj, CatPluginDecorator)
     
     @property
     def path(self):


### PR DESCRIPTION
# Description

Fixed a conflict in the automatic documentation generation process caused by the presence of two plugin.py files in the core code. The documentation script, which generates docs from docstrings, does so based on module names.

Related to issue #633 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
