### PR TITLE
Changed LLMGeminiChatConfig model from gemini to gemini-pro

### DIFF
--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -255,7 +255,7 @@ class LLMGeminiChatConfig(LLMSettings):
     The `LLMGeminiChatConfig` class is used to create an instance of the Gemini LLM model, which can be used to generate text in natural language.
     """
     google_api_key: str 
-    model: str = "gemini"
+    model: str = "gemini-pro"
     temperature: float =  0.1
     top_p: int = 1
     top_k: int =  1


### PR DESCRIPTION
# Description

Changed the model name inside LLMGeminiChatConfig. It was mistakenly set to gemini, but it needs to be gemini-pro.
[Reference](https://python.langchain.com/docs/integrations/chat/google_generative_ai)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
