### PR TITLE
Added gemini embedder support

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -3,6 +3,7 @@ import langchain
 from pydantic import BaseModel, ConfigDict
 from langchain.embeddings.fastembed import FastEmbedEmbeddings
 from cat.factory.custom_embedder import DumbEmbedder, CustomOpenAIEmbeddings
+from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
 
 # Base class to manage LLM configuration.
@@ -127,6 +128,24 @@ class EmbedderQdrantFastEmbedConfig(EmbedderSettings):
             "link": "https://qdrant.github.io/fastembed/",
         }
     )
+
+class EmbedderGeminiChatConfig(EmbedderSettings):
+    """Configuration for Gemini Chat Embedder.
+
+    This class contains the configuration for the Gemini Chat Embedder.
+    """
+
+    model_name: str = "models/embedding-001" # Default model https://python.langchain.com/docs/integrations/text_embedding/google_generative_ai
+    
+    _pyclass: Type = GoogleGenerativeAIEmbeddings
+
+    model_config = ConfigDict(
+        json_schema_extra = {
+            "humanReadableName": "Gemini Chat Embedder",
+            "description": "Configuration for Gemini Chat Embedder",
+            "link": "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text-embeddings?hl=en",
+        }
+    )
     
 
 
@@ -137,7 +156,8 @@ SUPPORTED_EMDEDDING_MODELS = [
     EmbedderOpenAIConfig,
     EmbedderAzureOpenAIConfig,
     EmbedderCohereConfig,
-    EmbedderQdrantFastEmbedConfig
+    EmbedderQdrantFastEmbedConfig,
+    EmbedderGeminiChatConfig,
 ]
 
 

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -5,6 +5,8 @@ from langchain.base_language import BaseLanguageModel
 from langchain.chat_models.base import BaseChatModel
 from langchain.llms import Cohere, OpenAI, AzureOpenAI
 from langchain.chat_models import ChatOpenAI, AzureChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
+
 
 from cat.db import crud
 from cat.factory.custom_llm import CustomOpenAI
@@ -198,6 +200,13 @@ class CheshireCat():
             embedder = embedders.EmbedderLlamaCppConfig.get_embedder_from_config(
                 {
                     "url": self._llm.url
+                }
+            )
+        elif type(self._llm) in [ChatGoogleGenerativeAI]:
+            embedder = embedders.EmbedderGeminiChatConfig.get_embedder_from_config(
+                {
+                    "model": self.embedder.model_name,
+                    "google_api_key": self._llm.google_api_key
                 }
             )
 

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -206,7 +206,7 @@ class CheshireCat():
             embedder = embedders.EmbedderGeminiChatConfig.get_embedder_from_config(
                 {
                     "model": self.embedder.model_name,
-                    "google_api_key": self._llm.google_api_key
+                    "google_api_key": self._llm.google_api_key,
                 }
             )
 


### PR DESCRIPTION
# Description

Added support for Gemini embedder.
It uses the same API key of the model. 
At the moment works under VPN.
[Reference](https://python.langchain.com/docs/integrations/text_embedding/google_generative_ai)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
