### PR TITLE
Fix Gemini embedder

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -138,7 +138,7 @@ class EmbedderGeminiChatConfig(EmbedderSettings):
     This class contains the configuration for the Gemini Embedder.
     """
     google_api_key: str
-    model_name: str = "models/embedding-001" # Default model https://python.langchain.com/docs/integrations/text_embedding/google_generative_ai
+    model: str = "models/embedding-001" # Default model https://python.langchain.com/docs/integrations/text_embedding/google_generative_ai
     
     _pyclass: Type = GoogleGenerativeAIEmbeddings
 

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -209,7 +209,7 @@ class CheshireCat():
         elif type(self._llm) in [ChatGoogleGenerativeAI]:
             embedder = embedders.EmbedderGeminiChatConfig.get_embedder_from_config(
                 {
-                    "model": self.embedder.model_name,
+                    "model": "models/embedding-001",
                     "google_api_key": self._llm.google_api_key,
                 }
             )


### PR DESCRIPTION
# Description

Fix the embedder settings changing `model_name` to `model` and set the default embedder's name when syncing the embedder to the same LLM provider.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
