### PR TITLE
Protocol and Api Key configuration in QdrantClient

### DIFF
--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -4,6 +4,7 @@ import uuid
 import socket
 from typing import Any, List, Iterable, Optional
 import requests
+from cat.utils import extract_domain_from_url, is_https
 
 from qdrant_client import QdrantClient
 from qdrant_client.qdrant_remote import QdrantRemote
@@ -63,6 +64,9 @@ class VectorMemory:
             self.vector_db = VectorMemory.local_vector_db
         else:
             qdrant_port = int(os.getenv("QDRANT_PORT", 6333))
+            qdrant_https = is_https(qdrant_host)
+            qdrant_host = extract_domain_from_url(qdrant_host)
+            qdrant_api_key = os.getenv("QDRANT_API_KEY")
 
             try:
                 s = socket.socket()
@@ -77,4 +81,6 @@ class VectorMemory:
             self.vector_db = QdrantClient(
                 host=qdrant_host,
                 port=qdrant_port,
+                https=qdrant_https,
+                api_key=qdrant_api_key
             )

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -4,6 +4,7 @@ import inspect
 from datetime import timedelta
 from cat.log import log
 from langchain.evaluation import StringDistance, load_evaluator, EvaluatorType
+from urllib.parse import urlparse
 
 
 def to_camel_case(text: str) -> str:
@@ -101,6 +102,19 @@ def get_static_path():
     """Allows exposing the static files' path."""
     return os.path.join(get_base_path(), "static/")
 
+def is_https(url):
+    try:
+        parsed_url = urlparse(url)
+        return parsed_url.scheme == 'https'
+    except Exception as e:
+        return False
+    
+def extract_domain_from_url(url):
+    try:
+        parsed_url = urlparse(url)        
+        return parsed_url.netloc + parsed_url.path
+    except Exception:
+        return url
 
 def explicit_error_message(e):
     # add more explicit info on "RateLimitError" by OpenAI, 'cause people can't get it


### PR DESCRIPTION
# Description

The current implementation of the QdrantClient connection setup does not support the specification of the HTTPS protocol. This omission leads to connectivity issues when attempting to connect to a Qdrant instance configured to accept only HTTPS connections.
You can't also configure a qdrant api key in the qdrant client statement.
With this PR:
-  You can (optionally) specify the qdrant host protocol (http or https) in the `QDRANT_HOST` environment variable and it wil be used in the qdrant client statement.
- You can (optionally) specify the qdrant api key throught the `QDRANT_API_KEY` environment variable and it wil be used in the qdrant client statement.

Related to issue #654

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
