### PR TITLE
Added hook `before_cat_stores_episodic_memory` to override the user message point params

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -290,14 +290,24 @@ class StrayCat:
 
             user_message = self.working_memory["user_message_json"]["text"]
 
+            doc = {
+                "page_content": user_message,
+                "metadata": {
+                    "source": self.user_id,
+                    "when": time.time()
+                }
+            }
+            doc = self.mad_hatter.execute_hook(
+                "before_cat_stores_episodic_memory", doc, cat=self
+            )
             # store user message in episodic memory
             # TODO: vectorize and store also conversation chunks
             #   (not raw dialog, but summarization)
             user_message_embedding = self.embedder.embed_documents([user_message])
             _ = self.memory.vectors.episodic.add_point(
-                user_message,
+                doc['page_content'],
                 user_message_embedding[0],
-                {"source": self.user_id, "when": time.time()},
+                doc['metadata'],
             )
 
             # build data structure for output (response and why with memories)

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -304,3 +304,35 @@ def before_cat_sends_message(message: dict, cat) -> dict:
     """
 
     return message
+
+
+# Hook called just before of inserting the user message document in vector memory
+@hook(priority=0)
+def before_cat_stores_episodic_memory(doc: Document, cat) -> Document:
+    """Hook the user message `Document` before is inserted in the vector memory.
+
+    Allows editing and enhancing a single `Document` before the Cat add it to the episodic vector memory.
+
+    Parameters
+    ----------
+    doc : Document
+        Langchain `Document` to be inserted in memory.
+    cat : CheshireCat
+        Cheshire Cat instance.
+
+    Returns
+    -------
+    doc : Document
+        Langchain `Document` that is added in the episodic vector memory.
+
+    Notes
+    -----
+    The `Document` has two properties::
+
+        `page_content`: the string with the text to save in memory;
+        `metadata`: a dictionary with at least two keys:
+            `source`: where the text comes from;
+            `when`: timestamp to track when it's been uploaded.
+
+    """
+    return doc

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -5,6 +5,7 @@ Here is a collection of methods to hook into the Cat execution pipeline.
 """
 
 from cat.mad_hatter.decorators import hook
+from langchain.docstore.document import Document
 
 
 # Called before cat bootstrap


### PR DESCRIPTION
# Description

With the hook `before_cat_stores_episodic_memory` you can change the user message point params before it is saved in episodic vector memory

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
