### PR TITLE
Update plugins.py

### DIFF
--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -14,6 +14,7 @@ router = APIRouter()
 
 
 # GET plugins
+@router.get("", include_in_schema=False)
 @router.get("/")
 async def get_available_plugins(
     request: Request,


### PR DESCRIPTION
This PR resolves a nasty error of redirect from /plugins to -> /plugins/, which breaks compatibility with SSL Offloading approach.

Please do not merge for now, this error may be somewere else. I'll reach you back after some checks