### PR TITLE
halved chunk size and overlap

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -108,8 +108,8 @@ class RabbitHole:
             self,
             stray,
             file: Union[str, UploadFile],
-            chunk_size: int = 512,
-            chunk_overlap: int = 128,
+            chunk_size: int = 256,
+            chunk_overlap: int = 64,
     ):
         """Load a file in the Cat's declarative memory.
 
@@ -159,8 +159,8 @@ class RabbitHole:
             self,
             stray,
             file: Union[str, UploadFile],
-            chunk_size: int = 512,
-            chunk_overlap: int = 128
+            chunk_size: int = 256,
+            chunk_overlap: int = 64
     ) -> List[Document]:
         """Load and convert files to Langchain `Document`.
 
@@ -241,8 +241,8 @@ class RabbitHole:
             file_bytes: str,
             source: str = None,
             content_type: str = "text/plain",
-            chunk_size: int = 512,
-            chunk_overlap: int = 128
+            chunk_size: int = 256,
+            chunk_overlap: int = 64
         ) -> List[Document]:
         """Convert string to Langchain `Document`.
 

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -17,10 +17,10 @@ async def upload_file(
     file: UploadFile,
     background_tasks: BackgroundTasks,
     chunk_size: int = Body(
-        default=512,
+        default=256,
         description="Maximum length of each chunk after the document is split (in characters)",
     ),
-    chunk_overlap: int = Body(default=128, description="Chunk overlap (in characters)"),
+    chunk_overlap: int = Body(default=64, description="Chunk overlap (in characters)"),
     stray = Depends(session),
 ) -> Dict:
     """Upload a file containing text (.txt, .md, .pdf, etc.). File content will be extracted and segmented into chunks.
@@ -63,10 +63,10 @@ async def upload_url(
         description="URL of the website to which you want to save the content"
     ),
     chunk_size: int = Body(
-        default=512,
+        default=256,
         description="Maximum length of each chunk after the document is split (in characters)",
     ),
-    chunk_overlap: int = Body(default=128, description="Chunk overlap (in characters)"),
+    chunk_overlap: int = Body(default=64, description="Chunk overlap (in characters)"),
     stray = Depends(session),
 ):
     """Upload a url. Website content will be extracted and segmented into chunks.


### PR DESCRIPTION
# Description

Halved chunk size from 512 to 256 and overlap from 128 to 64.

Related to issue #691 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
