### PR TITLE
Run Cheshire without docker

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,0 +1,2 @@
+/build
+/Cheshire_Cat.egg-info

--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -219,8 +219,9 @@ class CatLogEngine:
         if secure != '':
             secure = 's'
 
+        server_port = int(os.getenv("CAT_SERVER_PORT","1865"))
         cat_host = os.getenv("CORE_HOST", "localhost")
-        cat_port = os.getenv("CORE_PORT", "1865")
+        cat_port = os.getenv("CORE_PORT", server_port)
         cat_address = f'http{secure}://{cat_host}:{cat_port}'
 
         with open("cat/welcome.txt", 'r') as f:

--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -109,10 +109,13 @@ if __name__ == "__main__":
         }
 
     log_level = os.getenv("LOG_LEVEL", "info")
+    server_bind = os.getenv("CAT_SERVER_BIND", "0.0.0.0")
+    server_port = int(os.getenv("CAT_SERVER_PORT", "80"))
+
     uvicorn.run(
         "cat.main:cheshire_cat_api",
-        host="0.0.0.0",
-        port=80,
+        host=server_bind,
+        port=server_port,
         use_colors=True,
         log_level=log_level.lower(),
         **debug_config

--- a/core/cat/routes/static/admin.py
+++ b/core/cat/routes/static/admin.py
@@ -1,9 +1,11 @@
 import os
-import re
-import json
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
 
+cat_workdir = os.getenv("CAT_WORKDIR", "/")
+admin_path=os.path.join(cat_workdir,"admin")
+if not os.path.exists(admin_path):
+    raise FileExistsError(f"the {admin_path} folder doesn't exist")
 
 def mount(cheshire_cat_api):
 
@@ -11,7 +13,7 @@ def mount(cheshire_cat_api):
     mount_admin_spa(cheshire_cat_api)
 
     # note html=False because index.html needs to be injected with runtime information
-    cheshire_cat_api.mount("/admin", StaticFiles(directory="/admin/", html=False), name="admin")
+    cheshire_cat_api.mount("/admin", StaticFiles(directory=admin_path, html=False), name="admin")
 
 
 def mount_admin_spa(cheshire_cat_api):
@@ -34,7 +36,8 @@ def mount_admin_spa(cheshire_cat_api):
         # the admin sttic build is created during docker build from this repo:
         # https://github.com/cheshire-cat-ai/admin-vue
         # the files live inside the /admin folder (not visible in volume / cat code)
-        with open("/admin/index.html", 'r') as f:
+        index_path = os.path.join(admin_path, "index.html")
+        with open(index_path, 'r') as f:
             html = f.read()
 
         # TODO: this is ugly, should be done with beautiful soup or a template

--- a/readme/CONTRIBUTING.md
+++ b/readme/CONTRIBUTING.md
@@ -118,24 +118,32 @@ This guide is based on the **contributing-gen**. [Make your own](https://github.
 
 ## Running Without Docker
 If you want debug your code or also to understand better the codebase, it is possible run the cat without docker following these steps.
+
 I will assume that you know what is python, what is a virtual environment and how to activate it both in the console and in your IDE.
+
 If not, plase check on internet before apply some changes on your machine that you will regret in the future.
 
 
-1. from the core directory, create a virtual environment and activate it
-2. install the dependencing from the pyproject.toml file with the comand:
+1. From the core directory, create a virtual environment and activate it
+2. Install the dependencing from the pyproject.toml file with the comand:
   pip install --no-cache-dir .
 3. run
   python -c "import nltk; nltk.download('punkt');nltk.download('averaged_perceptron_tagger')
-4. create the worker folder used by the cat. You can create it from anywhere. The important thing is is should be accessible.
+4. Create the worker folder used by the cat. You can create it from anywhere. The important thing is is should be accessible.
 5. Inside the worker folder create the admin folder
 6. Go inside the admin folder and run
   curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
-7. set the environment variable CAT_WORKDIR to the worder folder path
-8. set the environment variable CAT_SERVER_PORT to the port where you want access the cat. Default port is 80, but some computer doesn't allow this port to be open. A good choise can be 1865 or 8080
-9. set the environment variable CAT_SERVER_BIND to the bind address. If you don't know what it mean, you can leave unset or set to "0.0.0.0". It only a secure setting so the generic "0.0.0.0" is fine you don't know what it mean
-10. go in the core folder and run python
+7. Set the environment variable CAT_WORKDIR to the worder folder path
+8. Set the environment variable CAT_SERVER_PORT to the port where you want access the cat. Default port is 80, but some computer doesn't allow this port to be open. A good choise can be 1865 or 8080
+9. Set the environment variable CAT_SERVER_BIND to the bind address. If you don't know what it mean, you can leave unset or set to "0.0.0.0". It only a secure setting so the generic "0.0.0.0" is fine you don't know what it mean
+10. Go in the core folder and run python cat/main.py
 
+### Some Usefull Tips
+
+- If you get the error "[Errno 13] Permission denied" usually it means you are using not allowed server PORT. 
+- The plugins will be installed in the source folder cat/plugins, not in he work dir.
+
+  
 
 
 

--- a/readme/CONTRIBUTING.md
+++ b/readme/CONTRIBUTING.md
@@ -20,6 +20,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
   - [Improving The Documentation](#improving-the-documentation)
+- [Running the Cat without docker](#running-without-docker)
 
 ## I Have a Question
 
@@ -113,3 +114,29 @@ See details on how to help with the docs [here](https://github.com/cheshire-cat-
 ## Attribution
 
 This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!
+
+
+## Running Without Docker
+If you want debug your code or also to understand better the codebase, it is possible run the cat without docker following these steps.
+I will assume that you know what is python, what is a virtual environment and how to activate it both in the console and in your IDE.
+If not, plase check on internet before apply some changes on your machine that you will regret in the future.
+
+
+1. from the core directory, create a virtual environment and activate it
+2. install the dependencing from the pyproject.toml file with the comand:
+  pip install --no-cache-dir .
+3. run
+  python -c "import nltk; nltk.download('punkt');nltk.download('averaged_perceptron_tagger')
+4. create the worker folder used by the cat. You can create it from anywhere. The important thing is is should be accessible.
+5. Inside the worker folder create the admin folder
+6. Go inside the admin folder and run
+  curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
+7. set the environment variable CAT_WORKDIR to the worder folder path
+8. set the environment variable CAT_SERVER_PORT to the port where you want access the cat. Default port is 80, but some computer doesn't allow this port to be open. A good choise can be 1865 or 8080
+9. set the environment variable CAT_SERVER_BIND to the bind address. If you don't know what it mean, you can leave unset or set to "0.0.0.0". It only a secure setting so the generic "0.0.0.0" is fine you don't know what it mean
+10. go in the core folder and run python
+
+
+
+
+


### PR DESCRIPTION
# Description

## Motivation
As developer,  when I develop, it seems much simpler to me running the cat  inside a virtual environment  on my host machine instead to run in a docker machine. In this way I can leverage on tools  on my IDE and I can debug without making strange hack. On the contrary, I see any benefit to develop using a  docker machine.

## Purpose of the change
I made some changes in the code that didn't allow it to run in a virtual enviroment without breacking the previous behavior  and add documentation on how to use it

## Implementations
Because the problem is a few fixed path in the codebase,  I change this values with the one get from environment variables in order to allow the developer to choice that working folder and the server port, using as default the previous ones.

Add also a brief description on how to use this features.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
