### PR TITLE
Resolve : https://github.com/cheshire-cat-ai/core/issues/723

### DIFF
--- a/core/cat/factory/custom_embedder.py
+++ b/core/cat/factory/custom_embedder.py
@@ -61,13 +61,15 @@ class CustomOpenAIEmbeddings(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         payload = json.dumps({"input": texts})
-        ret = httpx.post(self.url, data=payload, timeout=None)
+        headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+        ret = httpx.post(self.url, data=payload, timeout=None,headers=headers)
         ret.raise_for_status()
         return  [e['embedding'] for e in ret.json()['data']]
     
     def embed_query(self, text: str) -> List[float]:
         payload = json.dumps({"input": text})
-        ret = httpx.post(self.url, data=payload, timeout=None)
+        headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+        ret = httpx.post(self.url, data=payload, timeout=None,headers=headers)
         ret.raise_for_status()
         return ret.json()['data'][0]['embedding']
 


### PR DESCRIPTION
# Description

Resolution of the problem:
"""
I created a flask server to use SentenceTransformer("multi-qa-MiniLM-L6-cos-v1")

with EmbedderOpenAICompatibleConfig

I can't handle requests with error "POST /v1/embeddings HTTP/1.1" 415 -

In particular on the cat side I have the error
File "/app/cat/factory/custom_embedder.py", line 59, in embed_documents
ret.raise_for_status()
File "/usr/local/lib/python3.10/site-packages/httpx/_models.py", line 759, in raise_for_status
raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '415 UNSUPPORTED MEDIA TYPE' for url 'http://server:port/v1/embeddings'
"""
Related to issue #723

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
