### PR TITLE
Add text splitter hook

### DIFF
--- a/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/rabbithole.py
@@ -7,7 +7,7 @@ These hooks allow to intercept the uploaded documents at different places before
 """
 
 from typing import List
-
+from langchain.text_splitter import TextSplitter
 from langchain.docstore.document import Document
 
 from cat.mad_hatter.decorators import hook
@@ -32,6 +32,27 @@ def rabbithole_instantiates_parsers(file_handlers: dict, cat) -> dict:
         Edited dictionary of supported mime types and related parsers.
     """
     return file_handlers
+
+
+@hook(priority=0)
+def rabbithole_instantiates_splitter(text_splitter: TextSplitter, cat) -> TextSplitter:
+    """Hook the splitter used to split text in chunks.
+
+    Allows replacing the default text splitter to customize the splitting process.
+
+    Parameters
+    ----------
+    text_splitter : TextSplitter
+        The text splitter used by default.
+    cat : CheshireCat
+        Cheshire Cat instance.
+
+    Returns
+    -------
+    text_splitter : TextSplitter
+        An instance of a TextSplitter subclass.
+    """
+    return text_splitter
 
 
 # Hook called just before of inserting a document in vector memory


### PR DESCRIPTION
# Description

This PR aims to add a new hook to be able to customize the TextSplitter used by the RabbitHole when splitting chunks of text in different documents.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
