### PR TITLE
Preserve settings on plugin upgrade

### DIFF
--- a/core/cat/mad_hatter/plugin_extractor.py
+++ b/core/cat/mad_hatter/plugin_extractor.py
@@ -54,6 +54,11 @@ class PluginExtractor:
         extracted_path = os.path.join(to, self.id)
         # if folder exists, delete it as it will be replaced
         if os.path.exists(extracted_path):
+            settings_file_path = os.path.join(extracted_path, 'settings.json')
+            # check if settings.json exists in the folder
+            if os.path.isfile(settings_file_path):
+                # copy settings.json to the temporary directory
+                shutil.copy(settings_file_path, folder_to_copy)
             shutil.rmtree(extracted_path)
         # extracted plugin in plugins folder!
         shutil.move(folder_to_copy, extracted_path)


### PR DESCRIPTION
# Description

When you try to upgrade a plugin with some settings stored in it, the current behavior is to replace the entire folder without preserving the current settings.json file. I just added some lines to take care of it. As far as I can understand in the cited issue, settings are not the only thing that you may want to preserve after plugin upgrade. Dont know if you want to tackle it with a more extended approach.

Related to issue #718 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
