### PR TITLE
matryoshka openai

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -75,7 +75,7 @@ class EmbedderOpenAICompatibleConfig(EmbedderSettings):
 class EmbedderOpenAIConfig(EmbedderSettings):
     openai_api_key: str
     model: str = "text-embedding-3-small"
-    dimensions: Optional[int] = 1536
+    dimensions: Optional[int] = 1536 # it doesn't work with None, I think it's a FE problem
     _pyclass: Type = OpenAIEmbeddings
 
     model_config = ConfigDict(

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Type
+from typing import Type, Optional
 import langchain
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -74,7 +74,8 @@ class EmbedderOpenAICompatibleConfig(EmbedderSettings):
 
 class EmbedderOpenAIConfig(EmbedderSettings):
     openai_api_key: str
-    model: str = "text-embedding-ada-002"
+    model: str = "text-embedding-3-small"
+    dimensions: Optional[int] = 1536
     _pyclass: Type = OpenAIEmbeddings
 
     model_config = ConfigDict(

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -95,6 +95,7 @@ class EmbedderAzureOpenAIConfig(EmbedderSettings):
     openai_api_type: str = "azure"
     openai_api_version: str
     deployment: str
+    dimensions: Optional[int] = 1536 # it doesn't work with None, I think it's a FE problem
 
     _pyclass: Type = AzureOpenAIEmbeddings
 


### PR DESCRIPTION
# Description

Changed the default model for openai embedders from ada-oo2 to v3-small.
Introduct the new parameters dimensions.
For ada-002 dimensions must be 1536 because it doesn't support matryoshka embeddings.

Related to issue #777

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
