### PR TITLE
"before_cat_stores_procedural_memory" hook created and "agent_allowed_tools" hook called

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -53,6 +53,9 @@ class AgentManager:
             if procedure.metadata["type"] in ["tool","form"] and procedure.metadata["trigger_type"] in ["description", "start_example"]:
                 recalled_procedures_names.add(procedure.metadata["source"])
 
+        # call agent_allowed_tools hook
+        recalled_procedures_names = self.mad_hatter.execute_hook("agent_allowed_tools", recalled_procedures_names, cat=stray)
+
         # Get tools with that name from mad_hatter
         allowed_procedures: Dict[str, CatTool | CatForm] = {}
         allowed_tools: List[CatTool] = []

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -310,17 +310,23 @@ class CheshireCat:
         ]
         for t in active_triggers_to_be_embedded:
             print(t)
+           
+            metadata = {
+                "source": t["source"],
+                "type": t["type"],
+                "trigger_type": t["trigger_type"],
+                "when": time.time(),
+            }
+            metadata = self.mad_hatter.execute_hook(
+                "before_cat_stores_procedural_memory", metadata, cat=self
+            )
             trigger_embedding = self.embedder.embed_documents([t["content"]])
             self.memory.vectors.procedural.add_point(
                 t["content"],
                 trigger_embedding[0],
-                {
-                    "source": t["source"],
-                    "type": t["type"],
-                    "trigger_type": t["trigger_type"],
-                    "when": time.time(),
-                },
+                metadata,
             )
+           
             log.warning(
                 f"Newly embedded {t['type']} trigger: {t['source']}, {t['trigger_type']}, {t['content']}"
             )

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -332,3 +332,25 @@ def before_cat_stores_episodic_memory(doc: Document, cat) -> Document:
 
     """
     return doc
+
+# Hook called just before of inserting the tool or form in procedural vector memory
+@hook(priority=0)
+def before_cat_stores_procedural_memory(metadata: dict, cat) -> dict:
+    """Hook the tool or form metadata before is inserted in the vector memory.
+
+    Allows editing and enhancing a tool or form metadata before the Cat add it to the procedural vector memory.
+
+    Parameters
+    ----------
+    metedata : dict
+        metadata Dictionary to be inserted in procedural vector memory.
+    cat : CheshireCat
+        Cheshire Cat instance.
+
+    Returns
+    -------
+    metedata : dict
+        metadata Dictionary that is added in the procedural vector memory.
+
+    """
+    return metadata


### PR DESCRIPTION
added "before_cat_stores_procedural_memory" and "agent_allowed_tools" hooks.
Modified the following files:

"embed_procedures" method in cheshire_cat.py
"before_cat_stores_procedural_memory" method in flow.py
"execute_procedures_agent" method in agent_manager.py