### PR TITLE
refactor CatForm.message() method

### DIFF
--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -163,12 +163,33 @@ JSON:
         return new_model    
     
     def message(self):
+        state_methods = {
+            CatFormState.CLOSED: self.message_closed,
+            CatFormState.WAIT_CONFIRM: self.message_wait_confirm,
+            CatFormState.INCOMPLETE: self.message_incomplete
+        }
+        state_method = state_methods.get(self._state, lambda: {"output": "Invalid state"})
+        return state_method()
 
-        if self._state == CatFormState.CLOSED:
-            return {
-                "output": f"Form {type(self).__name__} closed"
-            }
-
+        
+    def message_closed(self):
+        return {
+            "output": f"Form {type(self).__name__} closed"
+        }
+    
+    def message_wait_confirm(self):
+        output = self._generate_base_message()
+        output += "\n --> Confirm? Yes or no?"
+        return {
+            "output": output
+        }
+    
+    def message_incomplete(self):
+        return {
+            "output": self._generate_base_message()
+        }
+    
+    def _generate_base_message(self):
         separator = "\n - "
         missing_fields = ""
         if self._missing_fields:
@@ -187,13 +208,7 @@ JSON:
 {missing_fields}
 {invalid_fields}
 """
-    
-        if self._state == CatFormState.WAIT_CONFIRM:
-            out += "\n --> Confirm? Yes or no?"
-
-        return {
-            "output": out
-        }
+        return out
 
     # Extract model informations from user message
     def extract(self):


### PR DESCRIPTION
# Description

Splitted the CatForm.message() method into 3 submethods (`message_closed`, `message_wait_confirm`, `message_incomplete`). In particular, `message_wait_confirm` and `message_incomplete` share a private method to format the json schema collected till that moment `_generate_base_message`.

Now it is easy for an implementer to override default methods and customize forms even more! (see the attached pic)

Related to issue #789 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas 
\
![Schermata del 2024-04-25 09-13-53](https://github.com/cheshire-cat-ai/core/assets/80841205/0b982d7f-9490-47aa-9ac5-9901a0d68e62)
