### PR TITLE
Skip `lost+found` directory

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -102,11 +102,17 @@ class MadHatter:
         log.info("ACTIVE PLUGINS:")
         log.info(self.active_plugins)
 
+        # Directories to skip
+        skip_directories = ['lost+found']
+
         # discover plugins, folder by folder
         for folder in all_plugin_folders:
-            self.load_plugin(folder)
-
             plugin_id = os.path.basename(os.path.normpath(folder))
+
+            if plugin_id in skip_directories:
+                continue
+
+            self.load_plugin(folder)
             
             if plugin_id in self.active_plugins:
                 self.plugins[plugin_id].activate()


### PR DESCRIPTION
# Description

Skip `lost+found` subdirectory in the plugin when mount volume for the plugin directory

Related to issue #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
