### PR TITLE
Update API Endpoints Base and Embedder to Version v2

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -207,3 +207,8 @@ def get_embedders_schemas():
         EMBEDDER_SCHEMAS[schema["title"]] = schema
 
     return EMBEDDER_SCHEMAS
+
+def get_embedders_class():
+    # Provide a dictionary containing the name of the embedder and its corresponding class.
+    return {config_class.model_json_schema()["title"]: config_class
+            for config_class in get_allowed_embedder_models()}

--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -61,15 +61,19 @@ cheshire_cat_api.add_middleware(
     allow_headers=["*"],
 )
 
-# Add routers to the middleware stack.
-cheshire_cat_api.include_router(base.router, tags=["Status"], dependencies=[Depends(check_api_key)])
+# Add routers to the middleware stack v1.
+cheshire_cat_api.include_router(base.router_v1, tags=["Status"], dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(settings.router, tags=["Settings"], prefix="/settings", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(llm.router, tags=["Large Language Model"], prefix="/llm", dependencies=[Depends(check_api_key)])
-cheshire_cat_api.include_router(embedder.router, tags=["Embedder"], prefix="/embedder", dependencies=[Depends(check_api_key)])
+cheshire_cat_api.include_router(embedder.router_v1, tags=["Embedder"], prefix="/embedder", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(plugins.router, tags=["Plugins"], prefix="/plugins", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(memory.router, tags=["Memory"], prefix="/memory", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(upload.router, tags=["Rabbit Hole"], prefix="/rabbithole", dependencies=[Depends(check_api_key)])
 cheshire_cat_api.include_router(websocket.router, tags=["WebSocket"])
+
+# Add routers to the middleware stack v2.
+cheshire_cat_api.include_router(base.router_v2, tags=["Status"], dependencies=[Depends(check_api_key)], prefix="/v2")
+cheshire_cat_api.include_router(embedder.router_v2, tags=["Embedder"], prefix="/v2/embedder", dependencies=[Depends(check_api_key)])
 
 # mount static files
 # this cannot be done via fastapi.APIrouter:

--- a/core/cat/routes/base.py
+++ b/core/cat/routes/base.py
@@ -1,16 +1,43 @@
-from fastapi import APIRouter, Depends, Request, Body, Query
-from typing import Dict
+from fastapi import APIRouter, Depends, Body
+from typing import Dict, List
 import tomli
+
 from cat.headers import session
+from cat.log import log
+from cat.looking_glass.stray_cat import StrayCat
+from pydantic import BaseModel
+
+# Default router
+router_v1 = APIRouter()
+
+# Router v2
+router_v2 = APIRouter()
+
+class HomeResponse(BaseModel):
+    status: str
+    version: str
 
 
-router = APIRouter()
+class MemoryResponse(BaseModel):
+    page_content: str
+    type: str
+    score: float
+    id: str
+    metadata: Dict[str,str|int|float]
+
+class MessageWhyResponse(BaseModel):
+    input: str
+    intermediate_steps: List
+    memory: Dict[str,List[MemoryResponse]]
+
+class CatResponse(BaseModel):
+    type: str
+    content: str
+    user_id: str
+    why: MessageWhyResponse
 
 
-# server status
-@router.get("/")
-async def home() -> Dict:
-    """Server status""" 
+def home() -> Dict:
     with open("pyproject.toml", "rb") as f:
         project_toml = tomli.load(f)["project"]
 
@@ -20,13 +47,49 @@ async def home() -> Dict:
     }
 
 
-@router.post("/message")
+# server status
+@router_v1.get("/", deprecated=True)
+async def home_v1() -> Dict:
+    """Server status""" 
+    log.warning("Deprecated: This endpoint will be removed in the next major version.")
+    return home()
+
+@router_v2.get("/", response_model=HomeResponse, response_model_exclude_none=True)
+async def home_v2():
+    """Server status""" 
+    
+    return home()
+
+
 async def message_with_cat(
+    payload: Dict,
+    stray: StrayCat
+) -> Dict:
+    
+    answer = await stray(payload)
+
+    return answer
+
+
+@router_v1.post("/message", deprecated=True)
+async def message_with_cat_v1(
     payload: Dict = Body({"text": "hello!"}),
     stray = Depends(session),
 ) -> Dict:
     """Get a response from the Cat"""
     
-    answer = await stray(payload)
+    answer = await message_with_cat(payload, stray)
+    log.warning("Deprecated: This endpoint will be removed in the next major version.")
+
+    return answer
+
+@router_v2.post("/message", response_model=CatResponse, response_model_exclude_none=True)
+async def message_with_cat_v2(
+    payload: Dict = Body({"text": "hello!"}),
+    stray = Depends(session),
+) -> Dict:
+    """Get a response from the Cat"""
+    
+    answer = await message_with_cat(payload, stray)
 
     return answer

--- a/core/cat/routes/embedder.py
+++ b/core/cat/routes/embedder.py
@@ -1,13 +1,30 @@
 from typing import Dict
 
 from fastapi import Request, APIRouter, Body, HTTPException
+from typing import Dict, List, Optional, Union, Type
+from pydantic import BaseModel
 
-from cat.factory.embedder import get_allowed_embedder_models,get_embedders_schemas
+from cat.factory.embedder import get_allowed_embedder_models,get_embedders_schemas, get_embedders_class
+from cat.factory.embedder import EmbedderQdrantFastEmbedConfig ,\
+        EmbedderOpenAIConfig,\
+        EmbedderAzureOpenAIConfig,\
+        EmbedderGeminiChatConfig,\
+        EmbedderOpenAICompatibleConfig,\
+        EmbedderCohereConfig,\
+        EmbedderDumbConfig,\
+        EmbedderFakeConfig, \
+        EmbedderSettings
+
 from cat.db import crud, models
 from cat.log import log
 from cat import utils
 
-router = APIRouter()
+
+# Default router
+router_v1 = APIRouter()
+
+# Router v2
+router_v2 = APIRouter()
 
 # general embedder settings are saved in settings table under this category
 EMBEDDER_SELECTED_CATEGORY = "embedder"
@@ -19,10 +36,54 @@ EMBEDDER_CATEGORY = "embedder_factory"
 EMBEDDER_SELECTED_NAME = "embedder_selected"
 
 
-# get configured Embedders and configuration schemas
-@router.get("/settings")
-def get_embedders_settings(request: Request) -> Dict:
+class EmbedderSettingResponse(BaseModel):
+    name:str
+    value: Optional[Union[EmbedderQdrantFastEmbedConfig ,\
+        EmbedderOpenAIConfig,\
+        EmbedderAzureOpenAIConfig,\
+        EmbedderGeminiChatConfig,\
+        EmbedderOpenAICompatibleConfig,\
+        EmbedderCohereConfig,\
+        EmbedderDumbConfig,\
+        EmbedderFakeConfig]] = None
+    schema:Dict
+
+    @classmethod
+    # Constructs and returns an instance of the class it belongs to, based on the validation of configuration settings for an embedder. 
+    # It takes as parameters a schema (a dictionary outlining required and optional settings), the name of the embedder class, the embedder class, and a dictionary of saved settings.
+    def get_embedder_setting_response(self, schema:Dict, embedder_class_name:str, embedder_class:Type[EmbedderSettings], saved_setting:Dict):
+        if len(saved_setting) == 0:
+            return self(
+                name=embedder_class_name,
+                schema= schema,
+                value=None
+            )
+            
+        none_value:bool = False
+        # If schema contains required fields and saved_setting is not empty
+        if "required" in schema:
+            # Check that all the required field are present in saved_setting, otherwise value = None 
+            req_setting_not_present:List[str] = [req_setting for req_setting in schema["required"] if req_setting not in saved_setting]
+            if len(req_setting_not_present) > 0:
+                log.warning(f"Required settings {req_setting_not_present} not present in {embedder_class_name}; setting value to None")
+                none_value = True
+        return self(
+            name=embedder_class_name,
+            # if none_value is false create EmbedderSettings passing the saved_setting
+            value = embedder_class.model_validate(saved_setting) if not none_value else None,
+            schema= schema,
+        )
+
+class EmbeddersSettingsResponse(BaseModel):
+    settings: List[EmbedderSettingResponse]
+    selected_configuration: str
+
+
+
+@router_v1.get("/settings", deprecated=True)
+def get_embedders_settings_v1(request: Request) -> Dict:
     """Get the list of the Embedders"""
+    log.warning("Deprecated: This endpoint will be removed in the next major version.")
 
     SUPPORTED_EMDEDDING_MODELS = get_allowed_embedder_models()
     # get selected Embedder, if any
@@ -59,12 +120,57 @@ def get_embedders_settings(request: Request) -> Dict:
         "selected_configuration": selected,
     }
 
-
-# get Embedder settings and its schema
-@router.get("/settings/{languageEmbedderName}")
-def get_embedder_settings(request: Request, languageEmbedderName: str) -> Dict:
-    """Get settings and schema of the specified Embedder"""
+@router_v2.get("/settings", response_model_exclude_none=True)
+def get_embedders_settings_v2(request: Request) -> EmbeddersSettingsResponse:
+    """Get the list of the Embedders"""
+    ccat = request.app.state.ccat
+    embedder_class_dict = get_embedders_class()
     
+
+    SUPPORTED_EMDEDDING_MODELS = get_allowed_embedder_models()
+    # get selected Embedder, if any
+    selected = crud.get_setting_by_name(name=EMBEDDER_SELECTED_NAME)
+    if selected is not None:
+        selected = selected["value"]["name"]
+    else:
+        # If DB does not contain a selected embedder, it means an embedder was automatically selected.
+        # Deduce selected embedder:
+        ccat = request.app.state.ccat
+        for embedder_config_class in reversed(SUPPORTED_EMDEDDING_MODELS):
+            if embedder_config_class._pyclass.default == type(ccat.embedder):
+                selected = embedder_config_class.__name__
+    
+    # get stored settings from db
+    saved_settings_list = crud.get_settings_by_category(category=EMBEDDER_CATEGORY)
+    saved_settings = { s["name"]: s for s in saved_settings_list }
+
+    settings = []
+    for class_name, schema in get_embedders_schemas().items():
+        
+        saved_setting = {}
+        if class_name in saved_settings:
+            saved_setting = saved_settings[class_name]["value"]
+
+        settings.append(
+            EmbedderSettingResponse.get_embedder_setting_response(
+                schema,
+                class_name,
+                embedder_class_dict[class_name],
+                saved_setting 
+            )
+        )
+
+    return EmbeddersSettingsResponse(
+        settings=settings,
+        selected_configuration=selected
+    )
+
+
+@router_v1.get("/settings/{languageEmbedderName}", deprecated=True)
+def get_embedder_settings_v1(request: Request, languageEmbedderName: str) -> Dict:
+    """Get settings and schema of the specified Embedder"""
+    log.warning("Deprecated: This endpoint will be removed in the next major version.")
+
     EMBEDDER_SCHEMAS = get_embedders_schemas()
     # check that languageEmbedderName is a valid name
     allowed_configurations = list(EMBEDDER_SCHEMAS.keys())
@@ -90,14 +196,41 @@ def get_embedder_settings(request: Request, languageEmbedderName: str) -> Dict:
         "schema": schema
     }
 
+@router_v2.get("/{languageEmbedderName}/settings", response_model_exclude_none=True)
+def get_embedder_settings_v2(request: Request, languageEmbedderName: str) -> EmbedderSettingResponse:
+    """Get settings and schema of the specified Embedder"""
 
-@router.put("/settings/{languageEmbedderName}")
-def upsert_embedder_setting(
+    embedder_class_dict = get_embedders_class()
+
+    embedder_schemas = get_embedders_schemas()
+    # check that languageEmbedderName is a valid name
+    allowed_configurations = list(embedder_schemas.keys())
+    if languageEmbedderName not in allowed_configurations:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"{languageEmbedderName} not supported. Must be one of {allowed_configurations}"
+            }
+        )
+    
+    setting = crud.get_setting_by_name(name=languageEmbedderName)
+    schema = embedder_schemas[languageEmbedderName]
+
+    setting = {} if setting is None else setting["value"]
+    
+    return EmbedderSettingResponse.get_embedder_setting_response(schema,languageEmbedderName,embedder_class_dict[languageEmbedderName],setting )
+
+
+
+@router_v1.put("/settings/{languageEmbedderName}", deprecated=True)
+def upsert_embedder_setting_v1(
     request: Request,
     languageEmbedderName: str,
     payload: Dict = Body({"openai_api_key": "your-key-here"}),
 ) -> Dict:
-    """Upsert the Embedder setting"""
+    """Upsert the Embedder setting"""    
+    ccat = request.app.state.ccat
+    log.warning("Deprecated: This endpoint will be removed in the next major version.")
 
     EMBEDDER_SCHEMAS = get_embedders_schemas()
     # check that languageModelName is a valid name
@@ -129,7 +262,6 @@ def upsert_embedder_setting(
         "value": final_setting["value"]
     }
 
-    ccat = request.app.state.ccat
     # reload llm and embedder of the cat
     ccat.load_natural_language()
     # crete new collections (different embedder!)
@@ -162,3 +294,106 @@ def upsert_embedder_setting(
     ccat.mad_hatter.find_plugins()
 
     return status
+
+
+@router_v2.put("/{languageEmbedderName}/settings", response_model_exclude_none=True)
+def upsert_embedder_setting_v2(
+    request: Request,
+    languageEmbedderName: str,
+    payload: Dict = Body({"openai_api_key": "your-key-here"}),
+) -> EmbedderSettingResponse:
+    """Upsert the Embedder setting"""
+
+    ccat = request.app.state.ccat
+    embedder_class_dict = get_embedders_class()
+
+    EMBEDDER_SCHEMAS = get_embedders_schemas()
+    # check that languageModelName is a valid name
+    allowed_configurations = list(EMBEDDER_SCHEMAS.keys())
+    if languageEmbedderName not in allowed_configurations:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"{languageEmbedderName} not supported. Must be one of {allowed_configurations}"
+            }
+        )
+    
+    # get selected config if any
+    selected = crud.get_setting_by_name(name=EMBEDDER_SELECTED_NAME)
+    if selected is not None:
+        current_settings = crud.get_setting_by_name(name=selected["value"]["name"])
+
+    # Check required field 
+    schema = EMBEDDER_SCHEMAS[languageEmbedderName]
+    # If schema contains required fields
+    if "required" in schema:
+        # Check that all the required fields are present in payload 
+        req_setting_not_present = [req_setting for req_setting in schema["required"] if req_setting not in payload]
+        if len(req_setting_not_present) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": f"Required field {req_setting_not_present} for {languageEmbedderName}  are not configured."
+                }
+            )
+
+    # Add that default field in payload
+    for property in schema["properties"]:
+        if "default" not in schema["properties"][property]:
+            # required field, not optional, skip it
+            continue
+        if property in payload:
+            # property in payload, skip it
+            continue
+        # property not in payload, add the default value
+        default_value = schema["properties"][property]["default"]
+        log.info(f"Insert in payload default property {property} : {default_value}")
+        payload[property] = default_value
+    
+    # create the setting and upsert it
+    final_setting = crud.upsert_setting_by_name(
+        models.Setting(name=languageEmbedderName, category=EMBEDDER_CATEGORY, value=payload)
+    )
+    crud.upsert_setting_by_name(
+        models.Setting(name=EMBEDDER_SELECTED_NAME, category=EMBEDDER_SELECTED_CATEGORY, value={"name":languageEmbedderName})
+    )
+
+    setting = final_setting["value"]
+    
+    try:
+        # reload llm and embedder of the cat
+        ccat.load_natural_language()
+        # crete new collections (different embedder!)
+        ccat.load_memory()
+        # recreate tools embeddings
+        ccat.mad_hatter.find_plugins()
+
+    except Exception as e:
+        log.error(e)
+        crud.delete_settings_by_category(category=EMBEDDER_SELECTED_CATEGORY)
+        crud.delete_settings_by_category(category=EMBEDDER_CATEGORY)
+
+        # if a selected config is present, restore it
+        if selected is not None:
+            languageEmbedderName = selected["value"]["name"]
+            crud.upsert_setting_by_name(
+                models.Setting(name=languageEmbedderName, category=EMBEDDER_CATEGORY, value=current_settings["value"])
+            )
+            crud.upsert_setting_by_name(
+                models.Setting(name=EMBEDDER_SELECTED_NAME, category=EMBEDDER_SELECTED_CATEGORY, value={"name":languageEmbedderName})
+            )
+            # reload llm and embedder of the cat
+            ccat.load_natural_language()
+
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": utils.explicit_error_message(e)
+            }
+        )
+
+    return EmbedderSettingResponse.get_embedder_setting_response(
+        schema,
+        languageEmbedderName,
+        embedder_class_dict[languageEmbedderName],setting 
+    )


### PR DESCRIPTION
# Description

This pull request introduces v2 of existing API endpoints: base and embedder. The update ensures that the previous version continues to operate (though it is now deprecated) while offering improved and additional functionalities in v2. The Goal is to maintain backward compatibility and encourage users to transition to the new version due to its enhanced capabilities.

Changes:
- **Deprecation Warning for Old API:** The existing version of the API will remain operational but log a warning about its deprecation to encourage migration to v2.
- **New v2 Endpoints:**
The endpoints now respond with models structured as JSON Schema to improve integration and consistency across services.
The endpoint /settings/{languageEmbedderName} has been updated to /{languageEmbedderName}/settings in v2, better semantic ordering
- **Endpoint Response Consistency:**
The upsert_embedder_setting_v2 endpoint has been modified to return the same response structure as get_embedder_settings_v2. This change simplifies the API and aligns the user experience across different operations. Also, the endpoint checks if the required fields are present in the current payload (otherwise raises an exception). Additionally, it enriches the payload by automatically inserting default values for any properties not supplied by the user but defined in the schema ( only for properties with a default value). This enhancement ensures greater consistency between the model representation and the stored data.

Related to issue #764 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
