### PR TITLE
Fixed content attribute BUG in agent_manager

### DIFF
--- a/core/cat/looking_glass/agent_manager.py
+++ b/core/cat/looking_glass/agent_manager.py
@@ -230,7 +230,7 @@ class AgentManager:
         output = memory_chain.invoke(
             agent_input, config=RunnableConfig(callbacks=[NewTokenHandler(stray)])
         )
-        agent_input["output"] = output.content
+        agent_input["output"] = output
 
         return agent_input
 


### PR DESCRIPTION
While trying to use the cat with Cohere API i found a bug in cat-->looking_glass-->agent_manager. Memory_chain.invoke returned a string but i was treated as an object. 