### PR TITLE
Added fallback to handle pip errors during plugin installation

### DIFF
--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -112,8 +112,9 @@ class MadHatter:
                 try:
                     self.plugins[plugin_id].activate()
                 except Exception as e:
-                    # Couldn't activate the plugin -> Delete it
-                    self.uninstall_plugin(plugin_id)
+                    # Couldn't activate the plugin -> Deactivate it
+                    if plugin_id in self.active_plugins:
+                        self.toggle_plugin(plugin_id)
                     raise e
                 
 
@@ -217,8 +218,7 @@ class MadHatter:
                 try:
                     self.plugins[plugin_id].activate()
                 except Exception as e:
-                    # Couldn't activate the plugin -> Delete it
-                    self.uninstall_plugin(plugin_id)
+                    # Couldn't activate the plugin
                     raise e
 
                 # Execute hook on plugin activation

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -109,7 +109,13 @@ class MadHatter:
             plugin_id = os.path.basename(os.path.normpath(folder))
             
             if plugin_id in self.active_plugins:
-                self.plugins[plugin_id].activate()
+                try:
+                    self.plugins[plugin_id].activate()
+                except Exception as e:
+                    # Couldn't activate the plugin -> Delete it
+                    self.uninstall_plugin(plugin_id)
+                    raise e
+                
 
         self.sync_hooks_tools_and_forms()
 
@@ -208,7 +214,12 @@ class MadHatter:
                 log.warning(f"Toggle plugin {plugin_id}: Activate")
 
                 # Activate the plugin
-                self.plugins[plugin_id].activate()
+                try:
+                    self.plugins[plugin_id].activate()
+                except Exception as e:
+                    # Couldn't activate the plugin -> Delete it
+                    self.uninstall_plugin(plugin_id)
+                    raise e
 
                 # Execute hook on plugin activation
                 # Activation hook must happen before actual activation,

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -65,7 +65,11 @@ class Plugin:
 
     def activate(self):
         # install plugin requirements on activation
-        self._install_requirements()
+        try:
+            self._install_requirements()
+        except Exception as e:
+            raise e
+            
 
         # Load of hooks and tools
         self._load_decorated_functions()
@@ -273,6 +277,13 @@ class Plugin:
                     subprocess.run(['pip', 'install', '--no-cache-dir', '-r', tmp.name], check=True)
                 except subprocess.CalledProcessError as e:
                     log.error(f"Error during installing {self.id} requirements: {e}")
+                    
+                    # Uninstall the previously installed packages
+                    log.info(f"Uninstalling requirements for: {self.id}")
+                    subprocess.run(['pip', 'uninstall', '-r', tmp.name], check=True)
+                    
+                    raise Exception(f"Error during {self.id} requirements installation")
+                    
                 
     # lists of hooks and tools
     def _load_decorated_functions(self):


### PR DESCRIPTION
# Description
Closes #821 
Added a fallback when pip errors happen. All the new packages installed by the plugin are removed, then the plugin is removed with an error message.

Related to issue #821 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
