### PR TITLE
fix experimental message endpoint

### DIFF
--- a/core/cat/routes/base.py
+++ b/core/cat/routes/base.py
@@ -3,6 +3,7 @@ from typing import Dict
 import tomli
 from cat.headers import session
 
+from cat.convo.messages import CatMessage
 
 router = APIRouter()
 
@@ -20,13 +21,11 @@ async def home() -> Dict:
     }
 
 
-@router.post("/message")
+@router.post("/message", response_model=CatMessage)
 async def message_with_cat(
     payload: Dict = Body({"text": "hello!"}),
     stray = Depends(session),
 ) -> Dict:
     """Get a response from the Cat"""
-    
-    answer = await stray(payload)
-
+    answer = await stray({"user_id": stray.user_id, **payload})
     return answer


### PR DESCRIPTION
# Description

Bugfix to adjust the current behaviour of the experimental message endpoint `/message`. I've also provided response_model to allow type inference on json schema autogenerated by fastapi

Related to issue #824 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
