### PR TITLE
Fix WhiteRabbit (it was always late)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@
 
 # CONFIG_FILE
 # CCAT_METADATA_FILE="cat/data/metadata.json"
+
+# Set container timezone
+# CCAT_TIMEZONE=Europe/Rome

--- a/compose.yml
+++ b/compose.yml
@@ -12,8 +12,14 @@ services:
     ports:
       - ${CCAT_CORE_PORT:-1865}:80
       - 5678:5678 # only for development purposes (take away in production)
+    environment:
+      # Timezone for Windows
+      - TZ=${TZ:-UTC}
     volumes:
       - ./core:/app
+      # Timezones for Linux and MacOS
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     command:
       - python
       - "-m"

--- a/compose.yml
+++ b/compose.yml
@@ -13,13 +13,10 @@ services:
       - ${CCAT_CORE_PORT:-1865}:80
       - 5678:5678 # only for development purposes (take away in production)
     environment:
-      # Timezone for Windows
-      - TZ=${TZ:-UTC}
+      # Timezone
+      - TZ=${CCAT_TIMEZONE:-UTC}
     volumes:
       - ./core:/app
-      # Timezones for Linux and MacOS
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
     command:
       - python
       - "-m"


### PR DESCRIPTION
# Description

WhiteRabbit was always late because the container's timezone wasn't the same as the host machine. This update fixes the problem without any change from the user perspective if using Linux or MacOS.
However it's a little bit tricky on Windows. User should set an environment variable before `docker-compose up` like follows:
```bash
$ set TZ=Europe/Rome
```
where `Europe/Rome` is chosen from this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).

To make it easier maybe we can create a bash script for windows to detect automatically the local timezone.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
