### PR TITLE
Enhance Cat Core and Host connectivity by adding host.docker.internal mapping in compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,8 @@ services:
     ports:
       - ${CCAT_CORE_PORT:-1865}:80
       - 5678:5678 # only for development purposes (take away in production)
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # This add an entry to /etc/hosts file in the container mapping host.docker.internal to the host machine IP addr, allowing the container to access services running on the host, not only on Win and Mac but also Linux. See https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host and https://docs.docker.com/reference/cli/docker/container/run/#add-host
     volumes:
       - ./core:/app
     command:


### PR DESCRIPTION
# Description

This PR enables `cheshire-cat-core` to connect with services running on the host machine across different operating systems.
This follows our conversation on Discord about difficulties encountered by some users when attempting to use `cheshire-cat-core` with an `ollama` instance on the host.

- Adding `extra_hosts` filed and mapping `host.docker.internal:host-gateway` in the Docker `compose.yml` file, permits  `cheshire-cat-core` to connect with any desired service running on the host machine regardless of the OS. 
- This is particularly useful for Docker Linux users to match the seamless connectivity provided by Docker Desktop on Windows and macOS.

More info on :
- Cheshirecat Discord server
- Docker docs about host-constainer connections [here](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host) and [here](https://docs.docker.com/reference/cli/docker/container/run/#add-host)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
