### PR TITLE
Fix classify method in stray

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -417,7 +417,7 @@ class StrayCat:
             # Send error as websocket message
             self.send_error(e)
     
-    def classify(self, sentence: str, labels: List[str] | Dict[str, List[str]]) -> str:
+    def classify(self, sentence: str, labels: List[str] | Dict[str, List[str]]) -> str | None:
         """Classify a sentence.
         
         Parameters
@@ -448,7 +448,7 @@ class StrayCat:
 
         """
 
-        if type(labels) in [dict, Dict]:
+        if isinstance(labels, dict):
             labels_names = labels.keys()
             examples_list = "\n\nExamples:"
             for label, examples in labels.items():
@@ -469,11 +469,10 @@ Allowed classes are:
 "{sentence}" -> """
 
         response = self.llm(prompt)
-        log.critical(response)
+        log.info(response)
 
-        for l in labels_names:
-            if l in response:
-                return l
+        if response in labels_names:
+            return response
         
         return None
 


### PR DESCRIPTION
# Description

Currently the `cat.classify()` method in StrayCat is looping over labels and checking if every label is a substring of the response (was this logic intentional?) which is the string classified by the LLM. This could lead to bugs if one defines his/her labels as substrings of one another. 
For instance, if you define your labels as: `['positive', 'not_so_positive', 'negative']`, even if the LLM classifies correctly the sentence as `not_so_positive` the method will return `positive`, since the label is a substring of the response.

I've also optimized type hinting and type checking for better readability.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
