### PR TITLE
[Feature] AWS Bedrock LLMs Implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,8 @@
 
 # Set container timezone
 # CCAT_TIMEZONE=Europe/Rome
+
+# AWS BEDROCK CONFIG VARIABLES
+# AWS_ACCESS_KEY_ID=access_key_id
+# AWS_SECRET_ACCESS_KEY=secret_access_key
+# AWS_DEFAULT_REGION=us-east-1

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -20,6 +20,7 @@ COPY ./pyproject.toml /app/pyproject.toml
 WORKDIR /app
 RUN pip install -U pip && \
     pip install --no-cache-dir . &&\
+    pip install boto3 &&\
     python3 -c "import nltk; nltk.download('punkt');nltk.download('averaged_perceptron_tagger')"
 
 ### COPY CAT CODE INSIDE THE CONTAINER (so it can be run standalone) ###

--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -16,6 +16,9 @@ def get_supported_env_variables():
         "CCAT_QDRANT_API_KEY": None,
         "CCAT_SAVE_MEMORY_SNAPSHOTS": "false",
         "CCAT_METADATA_FILE": "cat/data/metadata.json",
+        "AWS_ACCESS_KEY_ID": "",
+        "AWS_SECRET_ACCESS_KEY": "",
+        "AWS_DEFAULT_REGION": "",
     }
 
 

--- a/core/cat/factory/custom_llm.py
+++ b/core/cat/factory/custom_llm.py
@@ -1,10 +1,11 @@
-from typing import Optional, List, Any, Mapping, Dict
+from typing import Optional, List, Any, Mapping, Dict, ClassVar, Type
 import requests
 from fastapi import HTTPException
 
 from langchain_core.language_models.llms import LLM
 from langchain_openai.chat_models import ChatOpenAI
 from langchain_community.chat_models.ollama import ChatOllama
+from langchain_community.chat_models import BedrockChat
 
 from cat.log import log
 
@@ -85,7 +86,6 @@ class CustomOpenAI(ChatOpenAI):
         )
 
 
-
 class CustomOllama(ChatOllama):
     def __init__(self, **kwargs: Any) -> None:
         if "localhost" in kwargs["base_url"]:
@@ -98,3 +98,19 @@ class CustomOllama(ChatOllama):
         if kwargs["base_url"].endswith("/"):
             kwargs["base_url"] = kwargs["base_url"][:-1]
         super().__init__(**kwargs)
+
+
+class CustomBedrock(BedrockChat):
+    """Configuration for Bedrock Chat model
+    """
+
+    def __init__(self, model_id, temperature, top_p, top_k, **kwargs: Any):
+        super().__init__(
+            model_id=model_id,
+            model_kwargs={
+                "temperature": temperature,
+                "top_p": top_p,
+                "top_k": top_k,
+            },
+            **kwargs
+        )

--- a/core/cat/factory/custom_llm.py
+++ b/core/cat/factory/custom_llm.py
@@ -101,7 +101,9 @@ class CustomOllama(ChatOllama):
 
 
 class CustomBedrock(BedrockChat):
-    """Configuration for Bedrock Chat model
+    """
+    In order to set temperature, top_p and top_k as settings in the CheshireCat FE we need to re-elaborate those
+    parameters and put them into a model_kwargs dict that we will pass to BedrockChat
     """
 
     def __init__(self, model_id, temperature, top_p, top_k, **kwargs: Any):

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel, ConfigDict
 from cat.factory.custom_llm import LLMDefault, LLMCustom, CustomOpenAI, CustomOllama
 from cat.mad_hatter.mad_hatter import MadHatter
 
+from cat.factory.custom_llm import CustomBedrock
+
 
 # Base class to manage LLM configuration.
 class LLMSettings(BaseModel):
@@ -289,19 +291,21 @@ class LLMBedrockChatConfig(LLMSettings):
     """
 
     model_id: str = "anthropic.claude-3-sonnet-20240229-v1:0"
-    model_kwargs: ClassVar = {
-        "temperature": 0.7,
-        "top_p": 1,
-        "top_k": 2,
-    }
+    temperature: float = 0.7
+    top_p: float = 1
+    top_k: float = 2
 
-    _pyclass: Type = BedrockChat
+    _pyclass: Type = CustomBedrock
+
+    @classmethod
+    def get_llm_from_config(cls, config):
+        return cls._pyclass.default(**config)
 
     model_config = ConfigDict(
         json_schema_extra={
             "humanReadableName": "AWS Bedrock",
-            "description": "Configuration for Bedrock AWS LLM",
-            "link": "",
+            "description": "Configuration for AWS Bedrock LLMs",
+            "link": "https://aws.amazon.com/bedrock/",
         }
     )
 
@@ -319,8 +323,8 @@ def get_allowed_language_models():
         LLMOllamaConfig,
         LLMOpenAICompatibleConfig,
         LLMCustomConfig,
-        LLMDefaultConfig,
         LLMBedrockChatConfig,
+        LLMDefaultConfig,
     ]
 
     mad_hatter_instance = MadHatter()

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -8,8 +8,9 @@ from langchain_community.llms import (
 from langchain_openai import ChatOpenAI
 from langchain_cohere import ChatCohere
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_community.chat_models import BedrockChat
 
-from typing import Type
+from typing import Type, ClassVar
 import json
 from pydantic import BaseModel, ConfigDict
 
@@ -283,6 +284,28 @@ class LLMGeminiChatConfig(LLMSettings):
     )
 
 
+class LLMBedrockChatConfig(LLMSettings):
+    """Configuration for Bedrock Chat model
+    """
+
+    model_id: str = "anthropic.claude-3-sonnet-20240229-v1:0"
+    model_kwargs: ClassVar = {
+        "temperature": 0.7,
+        "top_p": 1,
+        "top_k": 2,
+    }
+
+    _pyclass: Type = BedrockChat
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "humanReadableName": "AWS Bedrock",
+            "description": "Configuration for Bedrock AWS LLM",
+            "link": "",
+        }
+    )
+
+
 def get_allowed_language_models():
     list_llms_default = [
         LLMOpenAIChatConfig,
@@ -297,6 +320,7 @@ def get_allowed_language_models():
         LLMOpenAICompatibleConfig,
         LLMCustomConfig,
         LLMDefaultConfig,
+        LLMBedrockChatConfig,
     ]
 
     mad_hatter_instance = MadHatter()


### PR DESCRIPTION
# Description

With this PR, we want to add AWS Bedrock to the other available LLMs in the CheshireCat Core.
In order to make it work, we need three new environment variables (which are used by boto3 in order to connect to AWS services):
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION

After this PR, the user will be able to choose to use Bedrock in the same settings where they set the other LLMs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
