### PR TITLE
Replace equals with levenshtein method

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -16,6 +16,8 @@ from cat.looking_glass.callbacks import NewTokenHandler
 from cat.memory.working_memory import WorkingMemory
 from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role
 
+from cat.utils import levenshtein_distance
+
 MSG_TYPES = Literal["notification", "chat", "error", "chat_token"]
 
 
@@ -471,10 +473,14 @@ Allowed classes are:
         response = self.llm(prompt)
         log.info(response)
 
-        if response in labels_names:
-            return response
-        
-        return None
+        # find the closest match and its score with levenshtein distance
+        best_label, score = min(
+            ((label, levenshtein_distance(response, label)) for label in labels_names),
+            key=lambda x: x[1]
+        )
+
+        # set 0.5 as threshold - let's see if it works properly
+        return best_label if score < 0.5 else None
 
     def stringify_chat_history(self, latest_n: int = 5) -> str:
         """Serialize chat history.


### PR DESCRIPTION
# Description

As discussed in issue #859, we should avoid strict equality checks for classified strings and instead use a fuzzy approach like the Levenshtein distance. To prevent outliers from being forced into the nearest label, a threshold is set at `0.5`. This is fairly permissive but should be suitable for most use cases. 

Let's try it out

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
