### PR TITLE
Track model interactions

### DIFF
--- a/core/cat/agents/memory_agent.py
+++ b/core/cat/agents/memory_agent.py
@@ -4,7 +4,7 @@ from langchain_core.prompts.chat import SystemMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.output_parsers.string import StrOutputParser
 
-from cat.looking_glass.callbacks import NewTokenHandler
+from cat.looking_glass.callbacks import NewTokenHandler, ModelInteractionHandler
 from cat.agents.base_agent import BaseAgent, AgentOutput
 
 class MemoryAgent(BaseAgent):
@@ -31,7 +31,7 @@ class MemoryAgent(BaseAgent):
             # convert to dict before passing to langchain
             # TODO: ensure dict keys and prompt placeholders map, so there are no issues on mismatches
             stray.working_memory.agent_input.model_dump(),
-            config=RunnableConfig(callbacks=[NewTokenHandler(stray)])
+            config=RunnableConfig(callbacks=[NewTokenHandler(stray), ModelInteractionHandler(stray, self.__class__.__name__)])
         )
 
         return AgentOutput(output=output)

--- a/core/cat/agents/procedures_agent.py
+++ b/core/cat/agents/procedures_agent.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from langchain.agents import AgentExecutor
 from langchain.prompts import ChatPromptTemplate
 from langchain_core.prompts.chat import SystemMessagePromptTemplate
-from langchain_core.runnables import RunnablePassthrough, RunnableLambda
+from langchain_core.runnables import RunnableConfig, RunnablePassthrough, RunnableLambda
 
 from cat.agents.base_agent import BaseAgent, AgentOutput
 from cat.looking_glass import prompts
@@ -17,6 +17,7 @@ from cat.mad_hatter.decorators.tool import CatTool
 from cat.mad_hatter.mad_hatter import MadHatter
 from cat.mad_hatter.plugin import Plugin
 from cat.log import log
+from cat.looking_glass.callbacks import ModelInteractionHandler
 
 
 """
@@ -153,7 +154,8 @@ class ProceduresAgent(BaseAgent):
         out = agent_executor.invoke(
             # convert to dict before passing to langchain
             # TODO: ensure dict keys and prompt placeholders map, so there are no issues on mismatches
-            stray.working_memory.agent_input.model_dump()
+            stray.working_memory.agent_input.model_dump(),
+            config=RunnableConfig(callbacks=[ModelInteractionHandler(stray, self.__class__.__name__)])
         )
 
         # Process intermediate steps and handle forms

--- a/core/cat/convo/messages.py
+++ b/core/cat/convo/messages.py
@@ -2,21 +2,34 @@ from typing import List, Literal
 from cat.utils import BaseModelDict
 from langchain_core.messages import BaseMessage, AIMessage, HumanMessage
 from enum import Enum
+from pydantic import BaseModel, Field
+import time
 
 
 class Role(Enum):
     AI = "AI"
     Human = "Human"
 
-class ModelInteraction(BaseModelDict):
-    """Class for wrapping model interaction"""
 
+class ModelInteraction(BaseModel):
     model_type: Literal["llm", "embedder"]
     source: str
     prompt: str
-    reply: str | List[float]
     input_tokens: int
+    started_at: float = Field(default_factory=lambda: time.time())
+
+
+class LLMModelInteraction(ModelInteraction):
+    model_type: Literal["llm"] = Field(default="llm")
+    reply: str
     output_tokens: int
+    ended_at: float
+
+
+class EmbedderModelInteraction(ModelInteraction):
+    model_type: Literal["embedder"] = Field(default="embedder")
+    source: str = Field(default="recall")
+    reply: List[float]
 
 
 class MessageWhy(BaseModelDict):
@@ -26,12 +39,13 @@ class MessageWhy(BaseModelDict):
         input (str): input message
         intermediate_steps (List): intermediate steps
         memory (dict): memory
+        model_interactions (List[LLMModelInteraction | EmbedderModelInteraction]): model interactions
     """
 
     input: str
     intermediate_steps: List
     memory: dict
-    model_interactions: List[ModelInteraction]
+    model_interactions: List[LLMModelInteraction | EmbedderModelInteraction]
 
 
 class CatMessage(BaseModelDict):
@@ -61,7 +75,7 @@ class UserMessage(BaseModelDict):
 
 
 def convert_to_Langchain_message(
-    messages: List[UserMessage | CatMessage],
+        messages: List[UserMessage | CatMessage],
 ) -> List[BaseMessage]:
     messages = []
     for m in messages:

--- a/core/cat/convo/messages.py
+++ b/core/cat/convo/messages.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 from cat.utils import BaseModelDict
 from langchain_core.messages import BaseMessage, AIMessage, HumanMessage
 from enum import Enum
@@ -7,6 +7,16 @@ from enum import Enum
 class Role(Enum):
     AI = "AI"
     Human = "Human"
+
+class ModelInteraction(BaseModelDict):
+    """Class for wrapping model interaction"""
+
+    model_type: Literal["llm", "embedder"]
+    source: str
+    prompt: str
+    reply: str | List[float]
+    input_tokens: int
+    output_tokens: int
 
 
 class MessageWhy(BaseModelDict):
@@ -21,6 +31,7 @@ class MessageWhy(BaseModelDict):
     input: str
     intermediate_steps: List
     memory: dict
+    model_interactions: List[ModelInteraction]
 
 
 class CatMessage(BaseModelDict):

--- a/core/cat/looking_glass/callbacks.py
+++ b/core/cat/looking_glass/callbacks.py
@@ -1,5 +1,9 @@
+from typing import Any, Dict, List
 from langchain.callbacks.base import BaseCallbackHandler
-
+from langchain_core.outputs.llm_result import LLMResult
+import tiktoken
+from cat.log import log
+from cat.convo.messages import ModelInteraction
 
 class NewTokenHandler(BaseCallbackHandler):
     def __init__(self, stray):
@@ -8,3 +12,38 @@ class NewTokenHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs) -> None:
         self.stray.send_ws_message(token, msg_type="chat_token")
+
+
+class ModelInteractionHandler(BaseCallbackHandler):
+    """
+    Langchain callback handler for tracking model interactions.
+    """
+
+    def __init__(self, stray, source: str):
+        self.stray = stray
+        self.stray.working_memory.model_interactions.append(
+            ModelInteraction(
+                model_type="llm",
+                source=source,
+                prompt="",
+                reply="",
+                input_tokens=0,
+                output_tokens=0,
+            )
+        )
+
+
+    def on_llm_start(self, serialized: Dict[str, Any], prompts: List[str], **kwargs) -> None:
+        encoding = tiktoken.get_encoding("cl100k_base")
+        input_tokens = sum(len(encoding.encode(prompt)) for prompt in prompts)
+        self.last_interaction.prompt = ''.join(prompts)
+        self.last_interaction.input_tokens = input_tokens
+
+    def on_llm_new_token(self, token: str, **kwargs) -> None:
+        self.last_interaction.output_tokens += 1
+
+    def on_llm_end(self, response: LLMResult, **kwargs) -> None:
+        self.last_interaction.reply = response.generations[0][0].text
+    @property
+    def last_interaction(self) -> ModelInteraction:
+        return self.stray.working_memory.model_interactions[-1]

--- a/core/cat/looking_glass/callbacks.py
+++ b/core/cat/looking_glass/callbacks.py
@@ -2,7 +2,9 @@ from typing import Any, Dict, List
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs.llm_result import LLMResult
 import tiktoken
-from cat.convo.messages import ModelInteraction
+from cat.convo.messages import LLMModelInteraction
+import time
+
 
 class NewTokenHandler(BaseCallbackHandler):
     def __init__(self, stray):
@@ -21,13 +23,13 @@ class ModelInteractionHandler(BaseCallbackHandler):
     def __init__(self, stray, source: str):
         self.stray = stray
         self.stray.working_memory.model_interactions.append(
-            ModelInteraction(
-                model_type="llm",
+            LLMModelInteraction(
                 source=source,
                 prompt="",
                 reply="",
                 input_tokens=0,
                 output_tokens=0,
+                ended_at=0,
             )
         )
 
@@ -35,7 +37,6 @@ class ModelInteractionHandler(BaseCallbackHandler):
         # cl100k_base is the most common encoding for OpenAI models such as GPT-3.5, GPT-4 - what about other providers?
         encoding = tiktoken.get_encoding("cl100k_base")
         return len(encoding.encode(text))
-
 
     def on_llm_start(self, serialized: Dict[str, Any], prompts: List[str], **kwargs) -> None:
         input_tokens = sum(self._count_tokens(prompt) for prompt in prompts)
@@ -45,7 +46,8 @@ class ModelInteractionHandler(BaseCallbackHandler):
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
         self.last_interaction.output_tokens = self._count_tokens(response.generations[0][0].text)
         self.last_interaction.reply = response.generations[0][0].text
+        self.last_interaction.ended_at = time.time()
 
     @property
-    def last_interaction(self) -> ModelInteraction:
+    def last_interaction(self) -> LLMModelInteraction:
         return self.stray.working_memory.model_interactions[-1]

--- a/core/cat/looking_glass/callbacks.py
+++ b/core/cat/looking_glass/callbacks.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs.llm_result import LLMResult
 import tiktoken
-from cat.log import log
 from cat.convo.messages import ModelInteraction
 
 class NewTokenHandler(BaseCallbackHandler):
@@ -32,18 +31,21 @@ class ModelInteractionHandler(BaseCallbackHandler):
             )
         )
 
+    def _count_tokens(self, text: str) -> int:
+        # cl100k_base is the most common encoding for OpenAI models such as GPT-3.5, GPT-4 - what about other providers?
+        encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(text))
+
 
     def on_llm_start(self, serialized: Dict[str, Any], prompts: List[str], **kwargs) -> None:
-        encoding = tiktoken.get_encoding("cl100k_base")
-        input_tokens = sum(len(encoding.encode(prompt)) for prompt in prompts)
+        input_tokens = sum(self._count_tokens(prompt) for prompt in prompts)
         self.last_interaction.prompt = ''.join(prompts)
         self.last_interaction.input_tokens = input_tokens
 
-    def on_llm_new_token(self, token: str, **kwargs) -> None:
-        self.last_interaction.output_tokens += 1
-
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
+        self.last_interaction.output_tokens = self._count_tokens(response.generations[0][0].text)
         self.last_interaction.reply = response.generations[0][0].text
+
     @property
     def last_interaction(self) -> ModelInteraction:
         return self.stray.working_memory.model_interactions[-1]

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -15,7 +15,7 @@ from cat.log import log
 from cat.looking_glass.cheshire_cat import CheshireCat
 from cat.looking_glass.callbacks import NewTokenHandler, ModelInteractionHandler
 from cat.memory.working_memory import WorkingMemory
-from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role, ModelInteraction
+from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role, EmbedderModelInteraction
 from cat.agents.base_agent import AgentOutput
 
 from cat.utils import levenshtein_distance
@@ -198,13 +198,10 @@ class StrayCat:
         
         # keep track of embedder model usage
         self.working_memory.model_interactions.append(
-            ModelInteraction(
-                model_type="embedder",
-                source="recall",
+            EmbedderModelInteraction(
                 prompt=recall_query,
                 reply=recall_query_embedding,
                 input_tokens=len(tiktoken.get_encoding("cl100k_base").encode(recall_query)),
-                output_tokens=0,
             )
         )
 

--- a/core/cat/memory/working_memory.py
+++ b/core/cat/memory/working_memory.py
@@ -1,7 +1,7 @@
 import time
 from typing import List
 from cat.utils import BaseModelDict
-from cat.convo.messages import Role, UserMessage
+from cat.convo.messages import Role, UserMessage, ModelInteraction
 from cat.experimental.form import CatForm
 
 
@@ -31,6 +31,9 @@ class WorkingMemory(BaseModelDict):
     episodic_memories: List = []
     declarative_memories: List = []
     procedural_memories: List = []
+
+    # track models usage
+    model_interactions: List[ModelInteraction] = []
 
     def update_conversation_history(self, who, message, why={}):
         """Update the conversation history.


### PR DESCRIPTION
# Description

This PR aims to prepare the groundwork for tracking model interactions and resource usage. 

@pieroit I believe this feature is a valuable addition to the framework because, especially for newcomers, the Cat is often treated as a black box, logs can sometimes be challenging to interpret. Providing a comprehensive observability of what is really happening under the hood can signficantly improve the dev ex with the framework.

However, Im still facing some ancestral doubts:

- Should `ModelInteraction` be a unique class? Since the embedder model interaction type has no output tokens, a fixed source (`recall`, is it the only one?) and a fixed type for reply `List[float]`, maybe it should be better to split `ModelInteraction` into two separated classes `LLMModelInteraction` and `EmbedderModelInteraction`?
- Another central issue is the standardized tokenizer. Following @pieroit 
suggestions in the issue,  I used `tiktoken`, the OpenAI tokenizer, for both input tokens and output tokens (to avoid excluding non-streaming APIs). I've stumbled upon different discussions online and it seems that the community is facing an error of `±15%` depending on the provider (here a [link](https://github.com/gkamradt/LLMTest_NeedleInAHaystack/issues/25) to an interesting discussion about that). I feel like we're taking a very rigid approach by using tiktoken everywhere, I've experimented also with response metadata but Langchain is still generic about [that](https://api.python.langchain.com/en/latest/outputs/langchain_core.outputs.llm_result.LLMResult.html#langchain_core.outputs.llm_result.LLMResult) and providers are not standardizing their responses.

Tested with OpenAI (gpt-4o, gpt-3.5-turbo), Cohere (command), Ollama (gemma2:9b).

Related to issue #864 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
