### PR TITLE
[Feature] Add memory properties to StrayCat

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -17,6 +17,7 @@ from cat.db import crud, models
 from cat.factory.embedder import get_embedder_from_name
 import cat.factory.embedder as embedders
 from cat.factory.llm import LLMDefaultConfig
+from cat.factory.embedder import EmbedderSettings
 from cat.factory.llm import get_llm_from_name
 from cat.agents.main_agent import MainAgent
 from cat.looking_glass.white_rabbit import WhiteRabbit
@@ -149,7 +150,7 @@ class CheshireCat:
 
         return llm
 
-    def load_language_embedder(self) -> embedders.EmbedderSettings:
+    def load_language_embedder(self) -> EmbedderSettings:
         """Hook into the  embedder selection.
 
         Allows to modify how the Cat selects the embedder at bootstrap time.

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -5,6 +5,7 @@ from typing_extensions import Protocol
 
 from langchain_core.language_models.llms import BaseLLM
 from langchain.base_language import BaseLanguageModel
+from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_community.llms import Cohere, OpenAI
 from langchain_openai import ChatOpenAI
@@ -150,7 +151,7 @@ class CheshireCat:
 
         return llm
 
-    def load_language_embedder(self) -> EmbedderSettings:
+    def load_language_embedder(self) -> Embeddings:
         """Hook into the  embedder selection.
 
         Allows to modify how the Cat selects the embedder at bootstrap time.

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -539,6 +539,10 @@ Allowed classes are:
     @property
     def user_id(self):
         return self.__user_id
+    
+    @property
+    def user_message(self):
+        return self.working_memory.user_message_json.text
 
     @property
     def _llm(self):

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -543,7 +543,11 @@ Allowed classes are:
     @property
     def user_message(self):
         return self.working_memory.user_message_json.text
-
+    
+    @property
+    def memory_vector_client(self):
+        return CheshireCat().memory.vectors.vector_db
+    
     @property
     def _llm(self):
         return CheshireCat()._llm

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -4,18 +4,27 @@ import traceback
 from typing import Literal, get_args, List, Dict, Union, Any
 
 from langchain.docstore.document import Document
+from langchain_core.embeddings import Embeddings
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain.base_language import BaseLanguageModel
+from qdrant_client import QdrantClient
+from cat.memory.vector_memory_collection import VectorMemoryCollection
+from cat.looking_glass.white_rabbit import WhiteRabbit
+from cat.mad_hatter.mad_hatter import MadHatter
+from cat.memory.long_term_memory import LongTermMemory
+from cat.rabbit_hole import RabbitHole
 from langchain_community.llms import BaseLLM
 from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
-
+from cat.factory.embedder import EmbedderSettings
 from fastapi import WebSocket
+
 
 from cat.log import log
 from cat.looking_glass.cheshire_cat import CheshireCat
 from cat.looking_glass.callbacks import NewTokenHandler
 from cat.memory.working_memory import WorkingMemory
 from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role
-from cat.agents.base_agent import AgentOutput
+from cat.agents.base_agent import AgentOutput, BaseAgent
 
 from cat.utils import levenshtein_distance
 
@@ -537,43 +546,55 @@ Allowed classes are:
         return langchain_chat_history
 
     @property
-    def user_id(self):
+    def user_id(self) -> str:
         return self.__user_id
     
     @property
-    def user_message(self):
+    def user_message(self) -> str:
         return self.working_memory.user_message_json.text
     
     @property
-    def memory_vector_client(self):
+    def memory_vector_client(self) -> QdrantClient:
         return CheshireCat().memory.vectors.vector_db
     
     @property
-    def _llm(self):
+    def episodic_memory(self) -> VectorMemoryCollection:
+        return CheshireCat().memory.vectors.episodic
+    
+    @property
+    def declarative_memory(self) -> VectorMemoryCollection:
+        return CheshireCat().memory.vectors.declarative
+    
+    @property
+    def procedural_memory(self) -> VectorMemoryCollection:
+        return CheshireCat().memory.vectors.procedural
+    
+    @property
+    def _llm(self) -> BaseLanguageModel:
         return CheshireCat()._llm
 
     @property
-    def embedder(self):
+    def embedder(self) -> Embeddings:
         return CheshireCat().embedder
 
     @property
-    def memory(self):
+    def memory(self) -> LongTermMemory:
         return CheshireCat().memory
 
     @property
-    def rabbit_hole(self):
+    def rabbit_hole(self) -> RabbitHole:
         return CheshireCat().rabbit_hole
 
     @property
-    def mad_hatter(self):
+    def mad_hatter(self) -> MadHatter:
         return CheshireCat().mad_hatter
 
     @property
-    def main_agent(self):
+    def main_agent(self) -> BaseAgent:
         return CheshireCat().main_agent
 
     @property
-    def white_rabbit(self):
+    def white_rabbit(self) -> WhiteRabbit:
         return CheshireCat().white_rabbit
 
     @property

--- a/core/cat/mad_hatter/decorators/tool.py
+++ b/core/cat/mad_hatter/decorators/tool.py
@@ -99,18 +99,20 @@ def tool(
 ) -> Callable:
     """
     Make tools out of functions, can be used with or without arguments.
+    
     Requires:
         - Function must be of type (str, cat) -> str
         - Function must have a docstring
+        
     Examples:
         .. code-block:: python
             @tool
             def search_api(query: str, cat) -> str:
-                # Searches the API for the query.
+                \"\"\"Searches the API for the query.\"\"\"
                 return "https://api.com/search?q=" + query
             @tool("search", return_direct=True)
             def search_api(query: str, cat) -> str:
-                # Searches the API for the query.
+               \"\"\"Searches the API for the query.\"\"\"
                 return "https://api.com/search?q=" + query
     """
 

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -1,5 +1,6 @@
 import sys
 import socket
+from typing import Dict, Literal
 from cat.utils import extract_domain_from_url, is_https
 
 from qdrant_client import QdrantClient
@@ -13,6 +14,8 @@ from cat.env import get_env
 # @singleton REFACTOR: worth it to have this (or LongTermMemory) as singleton?
 class VectorMemory:
     local_vector_db = None
+    
+    collections: Dict[Literal["episodic", "declarative", "procedural"], VectorMemoryCollection] = {}
 
     def __init__(
         self,
@@ -26,7 +29,6 @@ class VectorMemory:
         # - Episodic memory will contain user and eventually cat utterances
         # - Declarative memory will contain uploaded documents' content
         # - Procedural memory will contain tools and knowledge on how to do things
-        self.collections = {}
         for collection_name in ["episodic", "declarative", "procedural"]:
             # Instantiate collection
             collection = VectorMemoryCollection(

--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -62,7 +62,7 @@ async def upload_file(
 
     Note
     ----------
-    `chunk_size`, `chunk_overlap` anad `metadata` must be passed as form data.
+    `chunk_size`, `chunk_overlap` and `metadata` must be passed as form data.
     This is necessary because the HTTP protocol does not allow file uploads to be sent as JSON.
 
     Example


### PR DESCRIPTION
# Description
Related to issue #818, point 3

With this PR, I added new properties to StrayCat and some types (YES):
1.  `user_message(self) -> str`, return the query of the user 
2. `memory_vector_client(self) -> QdrantClient`, return the QdrantClient (Is is useful? personally yes, if i want to do some strange stuff...)
3. `<name collection>_memory(self) -> VectorMemoryCollection`, return a VectorMemoryCollection instance of the selected memory. Usuful to search, add or destroy vectors in a specific collection.

Nothing new is added, "old piero" did a great job when designing the VectorMemory!

To search points use `recall_memories_from_embedding(embedding, metadata=None, k=5, threshold=None )`.

Maybe #848 should be method of VectorMemoryCollection??


        

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
