### PR TITLE
fix: CCAT_CORE_USE_SECURE_PROTOCOLS

### DIFF
--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -82,9 +82,7 @@ def verbal_timedelta(td: timedelta) -> str:
 
 def get_base_url():
     """Allows exposing the base url."""
-    secure = get_env("CCAT_CORE_USE_SECURE_PROTOCOLS")
-    if secure not in ["", "false", "0"]:
-        secure = "s"
+    secure = "s" if get_env("CCAT_CORE_USE_SECURE_PROTOCOLS") in ("true", "1") else ""
     cat_host = get_env("CCAT_CORE_HOST")
     cat_port = get_env("CCAT_CORE_PORT")
     return f"http{secure}://{cat_host}:{cat_port}/"

--- a/core/tests/test_cat_utils.py
+++ b/core/tests/test_cat_utils.py
@@ -1,9 +1,17 @@
+import os
 import pytest
 
 from cat import utils
 
 
 def test_get_base_url():
+    assert utils.get_base_url() == "http://localhost:1865/"
+     # test when CCAT_CORE_USE_SECURE_PROTOCOLS is set
+    os.environ["CCAT_CORE_USE_SECURE_PROTOCOLS"] = "1"
+    assert utils.get_base_url() == "https://localhost:1865/"
+    os.environ["CCAT_CORE_USE_SECURE_PROTOCOLS"] = "0"
+    assert utils.get_base_url() == "http://localhost:1865/"
+    os.environ["CCAT_CORE_USE_SECURE_PROTOCOLS"] = ""
     assert utils.get_base_url() == "http://localhost:1865/"
 
 


### PR DESCRIPTION
# Description

- In compose/env file, set `CCAT_CORE_USE_SECURE_PROTOCOLS=0`
- issue: `get_base_url()` will return `http0://...`

This commit rewrites the condition in order to get the expected behavior:
- `CCAT_CORE_USE_SECURE_PROTOCOLS=1 | true` will give `https://...`
- everything else will give `http://...`

Added more tests for `get_base_url()` when `CCAT_CORE_USE_SECURE_PROTOCOLS` is set to a value

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
