### PR TITLE
add: new env variables to manage https proxy pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@
 # Decide to use https / wss secure protocols
 # CCAT_CORE_USE_SECURE_PROTOCOLS=true
 
+# Uvicorn and FastAPI operating behind https proxy
+# CCAT_HTTPS_PROXY_MODE=true
+
+# Comma separated list of IPs to trust with proxy headers. A wildcard '*' means always trust.
+# CCAT_CORS_FORWARDED_ALLOW_IPS="*"
+
 # Protect endpoints with an access token
 # CCAT_API_KEY=meow
 # CCAT_API_KEY_WS=meow2

--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -19,6 +19,8 @@ def get_supported_env_variables():
         "CCAT_JWT_SECRET": "secret",
         "CCAT_JWT_ALGORITHM": "HS256",
         "CCAT_JWT_EXPIRE_MINUTES": str(60 * 24),  # JWT expires after 1 day
+        "CCAT_HTTPS_PROXY_MODE": False,
+        "CCAT_CORS_FORWARDED_ALLOW_IPS": "*",
     }
 
 

--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -214,9 +214,7 @@ class CatLogEngine:
 
     def welcome(self):
         """Welcome message in the terminal."""
-        secure = get_env("CCAT_CORE_USE_SECURE_PROTOCOLS")
-        if secure != "":
-            secure = "s"
+        secure = "s" if get_env("CCAT_CORE_USE_SECURE_PROTOCOLS") in ("true", "1") else ""
 
         cat_host = get_env("CCAT_CORE_HOST")
         cat_port = get_env("CCAT_CORE_PORT")

--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -140,6 +140,13 @@ if __name__ == "__main__":
             "reload_includes": ["plugin.json"],
             "reload_excludes": ["*test_*.*", "*mock_*.*"],
         }
+    # uvicorn running behind an https proxy
+    proxy_pass_config = {}
+    if get_env("CCAT_HTTPS_PROXY_MODE") in ("1", "true"):
+        proxy_pass_config = {
+            "proxy_headers": True,
+            "forwarded_allow_ips": get_env("CCAT_CORS_FORWARDED_ALLOW_IPS"),
+        }
 
     uvicorn.run(
         "cat.main:cheshire_cat_api",
@@ -148,4 +155,5 @@ if __name__ == "__main__":
         use_colors=True,
         log_level=get_env("CCAT_LOG_LEVEL").lower(),
         **debug_config,
+        **proxy_pass_config,
     )


### PR DESCRIPTION
## Problem

- setup the cat with an https nginx proxy
- when using `/rabbithole` endopint, or any endopint that makes a redirect, fastapi/uvicorn will downgrade the connection to `http` because of the missing uvicorn server flags
- in case the original connection is https this will trigger the following error:

```
Mixed Content
The page at was loaded over HTTPS but requested an insecure resource
This request has been blocked the content must be served over HTTPS
```

## Proposed solution
- add new environment variable `CCAT_HTTPS_PROXY_MODE` in order to add the required flags when needed

## Reference
https://github.com/tiangolo/fastapi/discussions/9328#discussioncomment-8242245

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
