### PR TITLE
fix: change user password

### DIFF
--- a/core/cat/routes/users/users.py
+++ b/core/cat/routes/users/users.py
@@ -23,6 +23,7 @@ class UserCreate(UserBase):
 
 class UserUpdate(UserBase):
     username: str = Field(default=None, min_length=2)
+    password: str = Field(default=None, min_length=4)
     permissions: Dict[AuthResource, List[AuthPermission]] = None
     model_config: ConfigDict = {"extra": "forbid"}
 
@@ -91,7 +92,9 @@ def update_user(
             status_code=403,
             detail={"error": "Cannot edit admin user"}
         )
-    
+
+    if user.password:
+        user.password = hash_password(user.password)
     updated_user = stored_user | user.model_dump(exclude_unset=True)
     users_db[user_id] = updated_user
     crud.update_users(users_db)


### PR DESCRIPTION
# Description

With this fix it is now possible to update the password of a user.

**admin** user is still not editable. The `/users/{user_id}` endpoint returns `"Cannot edit admin user"`.

Related to issue #876 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
