### PR TITLE
Fix BUG POST /memory/collections/<collection_name>/points

### DIFF
--- a/core/cat/routes/memory.py
+++ b/core/cat/routes/memory.py
@@ -5,6 +5,7 @@ from fastapi import Query, Request, APIRouter, HTTPException, Depends
 from cat.auth.connection import HTTPAuth
 from cat.auth.permissions import AuthPermission, AuthResource
 
+import time
 
 class MemoryPointBase(BaseModel):
     content: str
@@ -179,6 +180,10 @@ async def create_memory_point(
     # ensure source is set
     if not point.metadata.get("source"):
         point.metadata["source"] = stray.user_id # this will do also for declarative memory
+
+    # ensure when is set
+    if not point.metadata.get("when"):
+        point.metadata["when"] = time.time() #if when is not in the metadata set the current time
 
     # create point
     qdrant_point = stray.memory.vectors.collections[collection_id].add_point(

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -21,8 +21,9 @@ from cat.mad_hatter.plugin import Plugin
 from cat.main import cheshire_cat_api
 from tests.utils import create_mock_plugin_zip
 
+import time
 
-
+FAKE_TIMESTAMP = 1705855981
 
 # substitute classes' methods where necessary for testing purposes
 def mock_classes(monkeypatch):
@@ -149,3 +150,12 @@ def stray(client):
 def apply_warning_filters():
     # ignore deprecation warnings due to langchain not updating to pydantic v2
     warnings.filterwarnings("ignore", category=PydanticDeprecatedSince20)
+
+#fixture for mock time.time function
+@pytest.fixture
+def patch_time_now(monkeypatch):
+
+    def mytime():
+        return FAKE_TIMESTAMP
+
+    monkeypatch.setattr(time, 'time', mytime)

--- a/core/tests/routes/memory/test_memory_points.py
+++ b/core/tests/routes/memory/test_memory_points.py
@@ -1,6 +1,6 @@
 import pytest
 from tests.utils import send_websocket_message, get_declarative_memory_contents
-
+from tests.conftest import FAKE_TIMESTAMP
 
 def test_point_deleted(client):
     # send websocket message
@@ -129,7 +129,7 @@ def create_point_wrong_collection(client):
 
 
 @pytest.mark.parametrize("collection", ["episodic", "declarative"])
-def test_create_memory_point(client, collection):
+def test_create_memory_point(client, patch_time_now, collection):
 
     # create a point
     content = "Hello dear"
@@ -144,7 +144,7 @@ def test_create_memory_point(client, collection):
     assert res.status_code == 200
     json = res.json()
     assert json["content"] == content
-    expected_metadata = {"source": "user", **metadata}
+    expected_metadata = {"when":FAKE_TIMESTAMP,"source": "user", **metadata}
     assert json["metadata"] == expected_metadata
     assert "id" in json
     assert "vector" in json


### PR DESCRIPTION
# Description

This pull request fix the bug of the endpoint POST /memory/collections/<collection_name>/points that does not automatically include "when" in metadata. 

Additionally, this PR introduces a utility test function called patch_time_now in conftest.py. This function is used to mock the time.time function for testing purposes.

Related to issue #888 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
