### PR TITLE
fix url to FAQ page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://cheshire-cat-ai.github.io/docs/) and [FAQs](https://cheshire-cat-ai.github.io/docs/faq/).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://cheshire-cat-ai.github.io/docs/) and [FAQs](https://cheshire-cat-ai.github.io/docs/faq/general/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/cheshire-cat-ai/core/issues/) that might help you. In case you have found a suitable issue and still need clarification, you can comment in the issue. If the problem you encountered is not strictly related to the Cat, try to search the internet for answers first.
 


### PR DESCRIPTION
# Description

https://cheshire-cat-ai.github.io/docs/faq/ links to a 404 page:
![Screenshot 2024-08-24 at 12 29 11](https://github.com/user-attachments/assets/b0bad551-e233-440a-a3de-152bfbed7179)


https://cheshire-cat-ai.github.io/docs/faq/general/ works as expected:
![Screenshot 2024-08-24 at 12 29 22](https://github.com/user-attachments/assets/de69e308-b237-45e3-9f7a-516487146f58)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
