### PR TITLE
Cat won't talk to strangers if not allowed to

### DIFF
--- a/core/cat/auth/connection.py
+++ b/core/cat/auth/connection.py
@@ -38,6 +38,8 @@ class ConnectionAuth(ABC):
         connection: HTTPConnection # Request | WebSocket,
     ) -> StrayCat:
 
+        # get protocol from Starlette request
+        protocol = connection.scope.get('type')
         # extract credentials (user_id, token_or_key) from connection
         user_id, credential = await self.extract_credentials(connection)
         auth_handlers = [
@@ -48,7 +50,7 @@ class ConnectionAuth(ABC):
         ]
         for ah in auth_handlers:
             user: AuthUserInfo = await ah.authorize_user_from_credential(
-                credential, self.resource, self.permission, user_id=user_id
+                protocol, credential, self.resource, self.permission, user_id=user_id
             )
             if user:
                 return await self.get_user_stray(user, connection)

--- a/core/cat/auth/connection.py
+++ b/core/cat/auth/connection.py
@@ -71,7 +71,7 @@ class ConnectionAuth(ABC):
 
 class HTTPAuth(ConnectionAuth):
 
-    async def extract_credentials(self, connection: Request) -> Tuple[str] | None:
+    async def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
         """
         Extract user_id and token/key from headers
         """
@@ -119,7 +119,7 @@ class HTTPAuth(ConnectionAuth):
 
 class WebSocketAuth(ConnectionAuth):
 
-    async def extract_credentials(self, connection: WebSocket) -> Tuple[str] | None:
+    async def extract_credentials(self, connection: WebSocket) -> Tuple[str, str] | None:
         """
         Extract user_id from WebSocket path params
         Extract token from WebSocket query string
@@ -165,7 +165,7 @@ class WebSocketAuth(ConnectionAuth):
 
 class CoreFrontendAuth(HTTPAuth):
 
-    async def extract_credentials(self, connection: Request) -> Tuple[str] | None:
+    async def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
         """
         Extract user_id from cookie
         """

--- a/core/cat/factory/custom_auth_handler.py
+++ b/core/cat/factory/custom_auth_handler.py
@@ -102,6 +102,14 @@ class CoreAuthHandler(BaseAuthHandler):
         http_api_key = get_env("CCAT_API_KEY")
         ws_api_key = get_env("CCAT_API_KEY_WS")
 
+        # no api keys -> everyone has access
+        if not http_api_key and not ws_api_key:
+            return AuthUserInfo(
+                id=user_id,
+                name=user_id,
+                permissions=get_base_permissions()
+            )
+
         # TODOAUTH: should we consider the user_id or just give
         #    admin permissions to all users with the right api keys?
 
@@ -114,7 +122,7 @@ class CoreAuthHandler(BaseAuthHandler):
             )
 
         # any http endpoint
-        if api_key == http_api_key:
+        if http_api_key and api_key == http_api_key:
             return AuthUserInfo(
                 id=user_id,
                 name=user_id,


### PR DESCRIPTION
# Description

Currently, if you set only the CCAT_WS_API_KEY you'll still be able to talk to the Cat even when no key is passed. 

I fixed it refactoring the `authorize_user_from_key` method. 

Actually, I think that, in the future, we should move out the control: "if no keys are set, then always pass", but is it strictly related to the AuthHandler? If so, then its right to keep it there even if out of scope. Plus, is it correct to gave base permissions if no keys are set? Probably would be better to distinguish even there the requested resource.

Related to issue #895 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
