### PR TITLE
Replace deprecated configuration type python with debugpy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
     "configurations": [
         {
             "name": "Python: Remote Attach to Cat",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
             "connect": {
                 "host": "localhost",


### PR DESCRIPTION
# Description

VSCode launch configuration type "python" is deprecated, replaced with "debugpy"