### PR TITLE
lowering recall threshold

### DIFF
--- a/core/cat/looking_glass/recall_settings.py
+++ b/core/cat/looking_glass/recall_settings.py
@@ -1,0 +1,31 @@
+"""Module for retrieving default configurations for episodic, declarative and procedural memories"""
+
+
+class RecallSettings:
+    """Class for retrieving default configurations for episodic, declarative and procedural memories"""
+
+    DEFAULT_K = 3
+    DEFAULT_TRESHOLD = 0.5
+
+    def _build_settings(
+        self,
+        recall_query_embedding,
+        user_id=None,
+        k=DEFAULT_K,
+        treshold=DEFAULT_TRESHOLD,
+    ):
+        return {
+            "embedding": recall_query_embedding,
+            "k": k,
+            "threshold": treshold,
+            "metadata": {"source": user_id} if user_id else None,
+        }
+
+    def default_episodic_config(self, recall_query_embedding, user_id):
+        return self._build_settings(recall_query_embedding, user_id)
+
+    def default_declarative_config(self, recall_query_embedding):
+        return self._build_settings(recall_query_embedding)
+
+    def default_procedural_config(self, recall_query_embedding):
+        return self._build_settings(recall_query_embedding)

--- a/core/cat/looking_glass/recall_settings.py
+++ b/core/cat/looking_glass/recall_settings.py
@@ -1,31 +1,30 @@
 """Module for retrieving default configurations for episodic, declarative and procedural memories"""
 
+from typing import Any
+from cat.utils import BaseModelDict
 
-class RecallSettings:
-    """Class for retrieving default configurations for episodic, declarative and procedural memories"""
 
-    DEFAULT_K = 3
-    DEFAULT_TRESHOLD = 0.5
+class RecallSettingsMetadata(BaseModelDict):
+    """Settigs's metadata for default configurations
 
-    def _build_settings(
-        self,
-        recall_query_embedding,
-        user_id=None,
-        k=DEFAULT_K,
-        treshold=DEFAULT_TRESHOLD,
-    ):
-        return {
-            "embedding": recall_query_embedding,
-            "k": k,
-            "threshold": treshold,
-            "metadata": {"source": user_id} if user_id else None,
-        }
+    Variables:
+        source (str): the source of the recall query
+    """
 
-    def default_episodic_config(self, recall_query_embedding, user_id):
-        return self._build_settings(recall_query_embedding, user_id)
+    source: str
 
-    def default_declarative_config(self, recall_query_embedding):
-        return self._build_settings(recall_query_embedding)
 
-    def default_procedural_config(self, recall_query_embedding):
-        return self._build_settings(recall_query_embedding)
+class RecallSettings(BaseModelDict):
+    """Class for retrieving default configurations for episodic, declarative and procedural memories
+
+    Variables:
+        embedding (Any): the embedding of the recall query - default None
+        k (int): the number of memories to return - default 3
+        threshold (float): the threshold - default 0.5
+        metadata (RecallSettingsMetadata): metadata - default None
+    """
+
+    embedding: Any
+    k: int = 3
+    threshold: float = 0.5
+    metadata: RecallSettingsMetadata = None

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -15,6 +15,7 @@ from fastapi import WebSocket
 from cat.log import log
 from cat.looking_glass.cheshire_cat import CheshireCat
 from cat.looking_glass.callbacks import NewTokenHandler, ModelInteractionHandler
+from cat.looking_glass.recall_settings import RecallSettings
 from cat.memory.working_memory import WorkingMemory
 from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role, EmbedderModelInteraction
 from cat.agents import AgentOutput
@@ -232,27 +233,13 @@ class StrayCat:
         self.mad_hatter.execute_hook("before_cat_recalls_memories", cat=self)
 
         # Setting default recall configs for each memory
-        # TODO: can these data structures become instances of a RecallSettings class?
-        default_episodic_recall_config = {
-            "embedding": recall_query_embedding,
-            "k": 3,
-            "threshold": 0.7,
-            "metadata": {"source": self.user_id},
-        }
+        recall_settings = RecallSettings()
 
-        default_declarative_recall_config = {
-            "embedding": recall_query_embedding,
-            "k": 3,
-            "threshold": 0.7,
-            "metadata": None,
-        }
+        default_episodic_recall_config = recall_settings.default_episodic_config(recall_query_embedding=recall_query_embedding, user_id=self.user_id)
 
-        default_procedural_recall_config = {
-            "embedding": recall_query_embedding,
-            "k": 3,
-            "threshold": 0.7,
-            "metadata": None,
-        }
+        default_declarative_recall_config = recall_settings.default_declarative_config(recall_query_embedding=recall_query_embedding)
+
+        default_procedural_recall_config = recall_settings.default_procedural_config(recall_query_embedding=recall_query_embedding)
 
         # hooks to change recall configs for each memory
         recall_configs = [

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -15,7 +15,7 @@ from fastapi import WebSocket
 from cat.log import log
 from cat.looking_glass.cheshire_cat import CheshireCat
 from cat.looking_glass.callbacks import NewTokenHandler, ModelInteractionHandler
-from cat.looking_glass.recall_settings import RecallSettings
+from cat.looking_glass.recall_settings import RecallSettingsMetadata, RecallSettings
 from cat.memory.working_memory import WorkingMemory
 from cat.convo.messages import CatMessage, UserMessage, MessageWhy, Role, EmbedderModelInteraction
 from cat.agents import AgentOutput
@@ -233,13 +233,18 @@ class StrayCat:
         self.mad_hatter.execute_hook("before_cat_recalls_memories", cat=self)
 
         # Setting default recall configs for each memory
-        recall_settings = RecallSettings()
+        default_episodic_recall_config = RecallSettings(
+            embedding=recall_query_embedding,
+            metadata=RecallSettingsMetadata(source=self.user_id),
+        )
 
-        default_episodic_recall_config = recall_settings.default_episodic_config(recall_query_embedding=recall_query_embedding, user_id=self.user_id)
+        default_declarative_recall_config = RecallSettings(
+            embedding=recall_query_embedding
+        )
 
-        default_declarative_recall_config = recall_settings.default_declarative_config(recall_query_embedding=recall_query_embedding)
-
-        default_procedural_recall_config = recall_settings.default_procedural_config(recall_query_embedding=recall_query_embedding)
+        default_procedural_recall_config = RecallSettings(
+            embedding=recall_query_embedding
+        )
 
         # hooks to change recall configs for each memory
         recall_configs = [


### PR DESCRIPTION
# Description

This is my first attempt to try to contribute a bit to this awesome project😹 
This commit will lower the recall threshold. It also separates the config introducing the `RecallSettings` class as suggested in [TODO](https://github.com/cheshire-cat-ai/core/blob/f14f2c0acebddd3f1f1efb6ba3b161bea45e9e3a/core/cat/looking_glass/stray_cat.py#L212)

I've set the following constant values:
```
    DEFAULT_K = 3
    DEFAULT_TRESHOLD = 0.5
```
please let me know if those values are appropriate.

Related to issue (#909)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
