### PR TITLE
feat: Change position of invalid credentials message and add alert style

### DIFF
--- a/core/cat/routes/static/core_static_folder/auth/auth.css
+++ b/core/cat/routes/static/core_static_folder/auth/auth.css
@@ -1,5 +1,3 @@
-
-
 #logo {
     width: 200px;
     height: 200px;
@@ -37,5 +35,12 @@ button:hover {
 }
 
 .error-message {
-    color: red;
+    margin: 5px;
+    text-align: center;
+    padding: 10px;
+    width: 300px;
+    border-radius: 5px;
+    background-color: #f8d7da;
+    border: 1px solid #f5c6cb;
+    color: #721c24;
 }

--- a/core/cat/routes/static/core_static_folder/auth/login.html
+++ b/core/cat/routes/static/core_static_folder/auth/login.html
@@ -11,6 +11,11 @@
     <form action="/auth/redirect" method="POST">
         <img id="logo" src="[[ url_for('core-static', path='/img/logo.svg') ]]">
         <div>
+        </div>
+        <div class="error-message">
+            [[ error_message ]]
+        </div>
+        <div>
             <input type="text" id="username" name="username" required autofocus placeholder="Username">
         </div>
         <div>
@@ -30,12 +35,6 @@
             </ul>
             Change their passwords after initial login as admin.    
         {% endif %}
-        <div>
-        </div>
-        <div class="error-message">
-            [[ error_message ]]
-        </div>
     </form>
-
 </body>
 </html>


### PR DESCRIPTION
- Edited the file 'login.html' to move the position of the invalid credentials message.
- Added style to the invalid credentials message in the file 'auth.css'. Changed background-color, text-alignment, etc.

Resolves issue: #927

# Description

As requested, I moved the invalid credentials message to a position where it is more visible to the user, and I also changed the .css so it looks more appealing.

Related to issue #927 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
