### PR TITLE
Run stray in threadpool to allow tool execution on http message endpoint

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -450,17 +450,22 @@ class StrayCat:
 
         return final_output
 
-    def run(self, user_message_json):
+    def run(self, user_message_json, return_message=False):
         try:
             cat_message = self.loop.run_until_complete(self.__call__(user_message_json))
-            # send message back to client
-            self.send_chat_message(cat_message)
+            if return_message:
+                # return the message for HTTP usage
+                return cat_message
+            else:
+                # send message back to client via WS
+                self.send_chat_message(cat_message)
         except Exception as e:
-            # Log any unexpected errors
             log.error(e)
             traceback.print_exc()
-            # Send error as websocket message
-            self.send_error(e)
+            if return_message:
+                return {"error": str(e)}
+            else:
+                self.send_error(e)
 
     def classify(
         self, sentence: str, labels: List[str] | Dict[str, List[str]]

--- a/core/cat/routes/base.py
+++ b/core/cat/routes/base.py
@@ -28,11 +28,6 @@ async def message_with_cat(
     stray=Depends(HTTPAuth(AuthResource.CONVERSATION, AuthPermission.WRITE)),
 ) -> Dict:
     """Get a response from the Cat"""
-    answer = await run_in_threadpool(stray_run, stray, {"user_id": stray.user_id, **payload})
+    user_message_json = {"user_id": stray.user_id, **payload}
+    answer = await run_in_threadpool(stray.run, user_message_json, True)
     return answer
-
-
-def stray_run(stray, user_message_json):
-    cat_message = stray.loop.run_until_complete(stray(user_message_json))
-    return cat_message
-

--- a/core/cat/routes/websocket.py
+++ b/core/cat/routes/websocket.py
@@ -22,7 +22,7 @@ async def receive_message(websocket: WebSocket, stray: StrayCat):
         user_message["user_id"] = stray.user_id
 
         # Run the `stray` object's method in a threadpool since it might be a CPU-bound operation.
-        await run_in_threadpool(stray.run, user_message)
+        await run_in_threadpool(stray.run, user_message, return_message=False)
 
 
 @router.websocket("/ws")


### PR DESCRIPTION
# Description

After a debug session with @valentimarco  we found that synchronous tools were not executed by the Stray if called via HTTP message endpoint, due to a problem with the event loop.

@Pingdred to the rescue, proposed to run the stray using FastAPI method `run_in_threadpool`.

Since the `_arun` method (in the procedural agent) may involve a mix of sync and async functions, using `run_in_threadpool` ensure that any potential blocking code is executed in a thread pool, avoiding event loop blockin. 

Am I right @Pingdred, @valentimarco?

Related to issue #921 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
