### PR TITLE
Example of CCAT_CORS_ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@
 # CCAT_LOG_LEVEL=INFO
 
 # CORS
-# CCAT_CORS_ALLOWED_ORIGINS=""
+# CCAT_CORS_ALLOWED_ORIGINS=https://example.org,https://www.example.org
 
 # Qdrant server
 # CCAT_QDRANT_HOST=<host>


### PR DESCRIPTION
# Description

Added example of using of parameter `CCAT_CORS_ALLOWED_ORIGINS` in the `.env.example` file