### PR TITLE
WebSocket Fix Proposal

### DIFF
--- a/core/cat/auth/connection.py
+++ b/core/cat/auth/connection.py
@@ -140,11 +140,10 @@ class WebSocketAuth(ConnectionAuth):
 
         if user.id in strays.keys():
             stray = strays[user.id]
-            # Close previus ws connection
-            if stray._StrayCat__ws:
-                await stray._StrayCat__ws.close()
+            await stray.close_connection()
+
             # Set new ws connection
-            stray._StrayCat__ws = connection
+            stray.reset_connection(connection)
             log.info(
                 f"New websocket connection for user '{user.id}', the old one has been closed."
             )


### PR DESCRIPTION
# Description

This is a proposal to fix [this issue](https://github.com/cheshire-cat-ai/core/issues/915).

#### FIX 1

The first step is to edit **stray_cat.py**:

Basically, we add a try-except block to the original code (`run` method) to handle the problem:

```python
from websockets.exceptions import ConnectionClosedOK

    def run(self, user_message_json, return_message=False):
        try:
            cat_message = self.loop.run_until_complete(self.__call__(user_message_json))
            if return_message:
                # return the message for HTTP usage
                return cat_message
            else:
                # send message back to client via WS
                self.send_chat_message(cat_message)
        except Exception as e:
            log.error(e)
            traceback.print_exc()
            if return_message:
                return {"error": str(e)}
            else:
                try:
                    self.send_error(e)
                except ConnectionClosedOK as ex:
                    log.warning(ex)
                    if self.__ws:
                        del self.__ws
                        self.__ws = None
```

It catches the *ConnectionClosedOK* exception, and, If the connection is closed with the code 1000 (normal closure), it logs a warning using *log.warning(ex)*.

Then, if the `ConnectionClosedOK` exception is caught, it deletes the `self.__ws` variable and sets it to `None`.

In the screencast below we can observe how the fix works against [reproduce.py](https://github.com/user-attachments/files/17024336/reproducer.md):

![fix1](https://github.com/user-attachments/assets/db22e39e-e754-4332-a8bf-66ef01e62bab)

### FIX 2

The first fix is used to handle this specific case: a given user closes the connection while the Cat is still providing an answer.

In case of a hypothetical different flow, we would run into the same problem again.

To avoid this, we can generalize the fix, adding this try-except block to the async method `get_user_stray` in connection.py:

```python
    if stray._StrayCat__ws:
    try: 
        await stray._StrayCat__ws.close()
    except RuntimeError as ex:
        log.warning(ex)
        if stray._StrayCat__ws:
            del stray._StrayCat__ws
            stray._StrayCat__ws = None
```

This fix ensure that, if we get a RuntimeError from WebSocket, we get a warning, and the *stray*, that once again is an inconsistent state, is cleaned up (same strategy we used for the first fix).

To avoid using a private attribute, we could extract this and implement a new method in the `StrayCat` class:

- **stray_cat.py**

```python
    async def close_connection(self):
        if self.__ws:
            try:
                await self.__ws.close()
            except RuntimeError as ex:
                log.warning(ex)
                if self.__ws:
                    del self.__ws
                    self.__ws = None
```

- **connection.py**

```python
        if user.id in strays.keys():
            stray = strays[user.id]
            await stray.close_connection()
```

In the screencast below, again, we can see how the second fix works against [reproduce.py](https://github.com/user-attachments/files/17024336/reproducer.md):

![fix2](https://github.com/user-attachments/assets/b1d0327a-e73d-4060-885e-a8001fb9756f)

Related to [this issue](https://github.com/cheshire-cat-ai/core/issues/915)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

I did not commented my code, I think it is not needed in this case.

As always, thanks for your work and support/review.