### PR TITLE
Do not remove the session manually

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -489,9 +489,6 @@ class StrayCat:
                     self.send_error(e)
                 except ConnectionClosedOK as ex:
                     log.warning(ex)
-                    if self.__ws:
-                        del self.__ws
-                        self.__ws = None
 
     def classify(
         self, sentence: str, labels: List[str] | Dict[str, List[str]]


### PR DESCRIPTION
# Description
Session handling is already managed centrally. Closing a session raises the WebSocketDisconnect exception, which is already handled in websocket.websocket_endpoint.

Additionally, removing the session here could obscure potential issues. For now, I suggest not removing the session, as this can help identify other unknowns.

Related to issue #915 and pull request #936

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
