### PR TITLE
Do not start the container manually during tests action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,9 +22,5 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - name: Cat up
-        run: docker compose up -d
       - name: Test
-        run: docker exec cheshire_cat_core python -m pytest --color=yes .
-      - name: Cat down
-        run: docker compose down
+        run: docker run cheshire-cat-core python -m pytest --color=yes .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test
-        run: docker run cheshire-cat-core python -m pytest --color=yes .
+        run: docker compose run cheshire-cat-core python -m pytest --color=yes .


### PR DESCRIPTION
# Description

We start the container just to run the tests however the launched instance is not used by the tests, FastAPI's `TestClient` doesn't need the Cat to be running; it starts the Cat instance on its own for each individual test.
Removed the up and down steps.

This should also speed up the tests step too.

Using `docker exec` instead of `docker run` because `exec` needs an already running container, while `run` creates the container before starting the command. `docker run` need the service name instead of the container name.

Not related to issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
