### PR TITLE
Update pyproject.toml conflict embedding BAAI/bge-multilingual-gemma2

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "langchain-openai==0.1.7",
     "langchain-google-genai==1.0.8",
     "langchain-cohere==0.1.5",
-    "huggingface-hub==0.20.3",
+    "huggingface-hub>=0.25.1",
     "beautifulsoup4==4.12.3",
     "pdfminer.six==20221105",
     "unstructured==0.12.6",


### PR DESCRIPTION
conflict embedding BAAI/bge-multilingual-gemma2

The error message you provided indicates that there is a dependency conflict between the version of huggingface-hub installed in your environment and one required by another package (likely transformers). Specifically, it seems that cheshire-cat 1.7.1 requires huggingface-hub==0.20.3, but you have version 0.25.2 installed.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related to issue #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
