### PR TITLE
adding session manager

### DIFF
--- a/core/cat/auth/session_manager.py
+++ b/core/cat/auth/session_manager.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+from cat.utils import singleton
+from cat.log import log
+
+from cat.auth.permissions import AuthUserInfo
+
+
+@singleton
+class SessionManager:
+    """
+    This class is responsible for strays session management
+
+    - adding new sessions
+    - expiring sessions
+    """
+
+    def __init__(self, strays: any) -> None:
+        self.strays = strays
+        self.sessions = {}
+
+    def add_or_refresh(self, user: AuthUserInfo, minutes: int = 60 * 24) -> None:
+        """
+        add new session setting expiration time to now plus x minutes
+        each session uses the expiration time as key and the value is a dict with user_id and stray
+        """
+
+        current_time = datetime.now(timezone.utc) + timedelta(minutes=minutes)
+
+        # if user_id is already in the session we removed it first
+        for timestamp in self.sessions:
+            if self.sessions[timestamp]["user_id"] == user.id:
+                self.sessions.pop(timestamp)
+                break
+
+        # then we create a new session
+        self.sessions[current_time] = {"user_id": user.id, "name": user.name}
+        pass
+
+    def evict_expired_sessions(self) -> int:
+        """
+        this method removes expired sessions
+        """
+
+        log.info("active sessions:")
+        log.info("*" * 20)
+
+        time_limit = datetime.now(timezone.utc)
+
+        for timestamp in self.sessions:
+            if timestamp >= time_limit:
+                log.info(f"expiration date: {timestamp} -> {self.sessions[timestamp]}")
+        log.info("*" * 20)
+
+        # retrieve all expired sessions
+        keys_to_remove = [
+            timestamp for timestamp in self.sessions if timestamp < time_limit
+        ]
+
+        # for each expired session key
+        for key in keys_to_remove:
+            # get the user_id
+            user_id = self.sessions[key]["user_id"]
+            if user_id in self.strays.keys():
+                log.info(
+                    f"deleting expired user: {self.strays[user_id].user_id} user_id: {user_id}"
+                )
+
+                # remove the users' stray
+                del self.strays[user_id]
+
+            # then remove the session using the key (timestamp)
+            self.sessions.pop(key)
+
+        expired_count = len(keys_to_remove)
+        if expired_count > 0:
+            log.info(f"{expired_count} sessions expired.")
+
+        return expired_count

--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -8,6 +8,7 @@ from fastapi.routing import APIRoute
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from cat.auth.session_manager import SessionManager
 
 from cat.log import log
 from cat.env import get_env, fix_legacy_env_variables
@@ -46,6 +47,8 @@ async def lifespan(app: FastAPI):
 
     # Dict of pseudo-sessions (key is the user_id)
     app.state.strays = {}
+
+    app.state.session_manager = SessionManager(app.state.strays)
 
     # set a reference to asyncio event loop
     app.state.event_loop = asyncio.get_running_loop()


### PR DESCRIPTION
# Description

This commit attempts to clean old strays after some time.  Currently, the expiration check is accomplished every time a new connection is made.

Related to issue #846 

# How to test this

1. Create two or three users named `test<n>` where `n` means the amount of minutes before expiration if no new connection is performed
2. Open your favourite browser and use some extension that separates sessions from one tab to another
3. Login with `test<n>` on a tab
4. use it a little bit then wait `n` minutes 
6. Login with `admin` on another tab
7. Go back to `test<n>` tab: the previous "session " of `test<n>` should be cleaned (the chat history should be empty)

# What is missing

Currently, the cleanup and the refresh of sessions happen only when a new connection is done. We need also to refresh the expiration when a user's message arrives. I need some guidance to understand where is the right place to invoke refresh on the code, I think the call should go in some line of https://github.com/cheshire-cat-ai/core/blob/f14f2c0acebddd3f1f1efb6ba3b161bea45e9e3a/core/cat/looking_glass/stray_cat.py#L322


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas