### PR TITLE
feat: fast_reply hook

### DIFF
--- a/core/cat/agents/main_agent.py
+++ b/core/cat/agents/main_agent.py
@@ -47,14 +47,13 @@ class MainAgent(BaseAgent):
         stray.working_memory.agent_input = agent_input
 
         # should we run the default agents?
-        fast_reply = {}
-        fast_reply = self.mad_hatter.execute_hook(
-            "agent_fast_reply", fast_reply, cat=stray
+        agent_fast_reply = self.mad_hatter.execute_hook(
+            "agent_fast_reply", {}, cat=stray
         )
-        if isinstance(fast_reply, AgentOutput):
-            return fast_reply
-        if isinstance(fast_reply, dict) and "output" in fast_reply:
-            return AgentOutput(**fast_reply)
+        if isinstance(agent_fast_reply, AgentOutput):
+            return agent_fast_reply
+        if isinstance(agent_fast_reply, dict) and "output" in agent_fast_reply:
+            return AgentOutput(**agent_fast_reply)
 
         # obtain prompt parts from plugins
         prompt_prefix = self.mad_hatter.execute_hook(

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -4,7 +4,8 @@ Here is a collection of methods to hook into the *Agent* execution pipeline.
 
 """
 
-from typing import List, Union, Dict
+from typing import List, Dict
+from cat.agents import AgentOutput
 
 from cat.mad_hatter.decorators import hook
 
@@ -30,36 +31,28 @@ def before_agent_starts(agent_input: Dict, cat) -> Dict:
 
 
 @hook(priority=0)
-def agent_fast_reply(fast_reply, cat) -> Union[None, Dict]:
-    """This hook is useful to shortcut the Cat response.
-    If you do not want the agent to run, return the final response from here and it will end up in the chat without the agent being executed.
+def agent_fast_reply(agent_fast_reply: dict, cat) -> None | dict | AgentOutput:
+    """This hook allows for a fast response after memory recall but before full agent execution.
+    It's useful for custom agent logic or when you want to use recalled memories but avoid the main agent.
 
     Parameters
     --------
-    fast_reply: dict
-        Input is dict (initially empty), which can be enriched whith an "output" key with the shortcut response.
+    agent_fast_reply: dict
+        An initially empty dict that can be populated with a response.
     cat : CheshireCat
         Cheshire Cat instance.
 
     Returns
     --------
     response : Union[None, Dict]
-        Cat response if you want to avoid using the agent, or None / {} if you want the agent to be executed.
+        If you want to bypass the main agent, return an AgentOutput or a dict with an "output" key.
+        Return None or an empty dict to continue with normal execution.
         See below for examples of Cat response
 
     Examples
     --------
 
-    Example 1: can't talk about this topic
-    ```python
-    # here you could use cat._llm to do topic evaluation
-    if "dog" in agent_input["input"]:
-        return {
-            "output": "You went out of topic. Can't talk about dog."
-        }
-    ```
-
-    Example 2: don't remember (no uploaded documents about topic)
+    Example 1: don't remember (no uploaded documents about topic)
     ```python
     num_declarative_memories = len( cat.working_memory.declarative_memories )
     if num_declarative_memories == 0:
@@ -69,7 +62,7 @@ def agent_fast_reply(fast_reply, cat) -> Union[None, Dict]:
     ```
     """
 
-    return fast_reply
+    return agent_fast_reply
 
 
 @hook(priority=0)

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -44,7 +44,7 @@ def agent_fast_reply(agent_fast_reply: dict, cat) -> None | dict | AgentOutput:
 
     Returns
     --------
-    response : Union[None, Dict]
+    response : None | dict | AgentOutput
         If you want to bypass the main agent, return an AgentOutput or a dict with an "output" key.
         Return None or an empty dict to continue with normal execution.
         See below for examples of Cat response

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -3,6 +3,7 @@
 Here is a collection of methods to hook into the Cat execution pipeline.
 
 """
+from cat.convo.messages import CatMessage
 
 from cat.mad_hatter.decorators import hook
 from langchain.docstore.document import Document
@@ -334,3 +335,37 @@ def before_cat_stores_episodic_memory(doc: Document, cat) -> Document:
 
     """
     return doc
+
+@hook(priority=0)
+def fast_reply(fast_reply: dict, cat) -> None | dict | CatMessage:
+    """This hook allows for an immediate response, bypassing memory recall and agent execution.
+    It's useful for canned replies, custom LLM chains / agents, topic evaluation, direct LLM interaction and so on.
+
+    Parameters
+    --------
+    fast_reply: dict
+        An initially empty dict that can be populated with a response.
+    cat : CheshireCat
+        Cheshire Cat instance.
+
+    Returns
+    --------
+    response : None | Dict | CatMessage
+        If you want to short-circuit the normal flow, return a CatMessage or a dict with an "output" key.
+        Return None or an empty dict to continue with normal execution.
+        See below for examples of Cat response
+
+    Examples
+    --------
+
+    Example 1: can't talk about this topic
+    ```python
+    # here you could use cat._llm to do topic evaluation
+    if "dog" in cat.working_memory.user_message_json.text:
+        return {
+            "output": "You went out of topic. Can't talk about dog."
+        }
+    ```
+    """
+
+    return fast_reply

--- a/core/cat/mad_hatter/core_plugin/hooks/flow.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/flow.py
@@ -350,7 +350,7 @@ def fast_reply(fast_reply: dict, cat) -> None | dict | CatMessage:
 
     Returns
     --------
-    response : None | Dict | CatMessage
+    response : None | dict | CatMessage
         If you want to short-circuit the normal flow, return a CatMessage or a dict with an "output" key.
         Return None or an empty dict to continue with normal execution.
         See below for examples of Cat response

--- a/core/tests/looking_glass/test_stray_cat.py
+++ b/core/tests/looking_glass/test_stray_cat.py
@@ -4,7 +4,7 @@ import asyncio
 from cat.looking_glass.stray_cat import StrayCat
 from cat.memory.working_memory import WorkingMemory
 from cat.convo.messages import MessageWhy, CatMessage
-
+from cat.mad_hatter.decorators.hook import CatHook
 
 @pytest.fixture
 def stray(client):
@@ -65,3 +65,29 @@ def test_recall_to_working_memory(stray):
     assert stray.working_memory.recall_query == msg_text
     assert len(stray.working_memory.episodic_memories) == 1
     assert stray.working_memory.episodic_memories[0][0].page_content == msg_text
+
+
+def test_stray_fast_reply_hook(stray):
+    user_msg = "hello"
+    fast_reply_msg = "This is a fast reply"
+
+    def fast_reply_hook(fast_reply: dict, cat):
+        if user_msg in cat.working_memory.user_message_json.text:
+            fast_reply["output"] = fast_reply_msg
+            return fast_reply
+
+    fast_reply_hook = CatHook(name="fast_reply", func=fast_reply_hook, priority=0)
+    fast_reply_hook.plugin_id = "fast_reply_hook"
+    stray.mad_hatter.hooks["fast_reply"] = [fast_reply_hook]
+
+    msg = {"text": user_msg, "user_id": "Alice"}
+
+    # send message
+    stray.loop.run_until_complete(stray.__call__(msg))
+    # used to check if the user message was stored in episodic memory
+    stray.recall_relevant_memories_to_working_memory(user_msg)
+
+    assert stray.working_memory.user_message_json.text == user_msg
+    assert stray.working_memory.history[-2]["message"] == user_msg
+    assert stray.working_memory.history[-1]["message"] == fast_reply_msg
+    assert len(stray.working_memory.episodic_memories) == 1


### PR DESCRIPTION
# Description

An attempt to tackle the related issue

- The new hook skips the memory recall and the main agent
- The user message that triggers the hook is still added to the episodic memory
- Conversation history is updated

---
- The `why` is not populated, not sure how to handle it in this case
- Not clear to me what "introduce proper cleaning of working memory" means

Related to issue #868 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
