### PR TITLE
StrayCat ave user_data in init, but not possible use it

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -35,6 +35,8 @@ class StrayCat:
         ws: WebSocket = None,
     ):
         self.__user_id = user_id
+        self.__user_data = user_data
+
         self.working_memory = WorkingMemory()
 
         # attribute to store ws connection
@@ -578,7 +580,11 @@ Allowed classes are:
     @property
     def user_id(self):
         return self.__user_id
-
+    
+    @property
+    def user_data(self):
+        return self.__user_data
+    
     @property
     def _llm(self):
         return CheshireCat()._llm

--- a/core/tests/routes/test_session.py
+++ b/core/tests/routes/test_session.py
@@ -17,6 +17,8 @@ def test_session_creation_from_websocket(client):
     assert "Alice" in strays
     assert isinstance(strays["Alice"], StrayCat)
     assert strays["Alice"].user_id == "Alice"
+    assert hasattr(strays["Alice"], "user_data")
+    assert strays["Alice"].user_data.id == "Alice"
     convo = strays["Alice"].working_memory.history
     assert len(convo) == 2
     assert convo[0]["who"] == "Human"


### PR DESCRIPTION
# Description

With the new authentication engine it is possible to enrich the AuthUserInfo object with permissions and even extra information. These are passed to the constructor, but then it is not possible to retrieve this useful information.

![image](https://github.com/user-attachments/assets/31b7eaba-db24-426b-b214-06d8cd66aef3)

What I say is easy to test with the test I have updated and which fails if we do not implement the appropriate property.

With this pull request we add the property and this codi is covered by the appropriate test that verifies the existence of the property and the value of the base key id

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
