### PR TITLE
New "*endpoint" decorators for custom endpoint creations

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -61,16 +61,18 @@ class CheshireCat:
         """
 
         # bootstrap the Cat! ^._.^
+
+        # get reference to the FastAPI app
         self.fastapi_app = fastapi_app
+
+        # load AuthHandler
+        self.load_auth()
 
         # Start scheduling system
         self.white_rabbit = WhiteRabbit()
 
         # instantiate MadHatter (loads all plugins' hooks and tools)
         self.mad_hatter = MadHatter()
-
-        # load AuthHandler
-        self.load_auth()
 
         # allows plugins to do something before cat components are loaded
         self.mad_hatter.execute_hook("before_cat_bootstrap", cat=self)

--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -54,7 +54,7 @@ class CheshireCat:
 
     """
 
-    def __init__(self):
+    def __init__(self, fastapi_app):
         """Cat initialization.
 
         At init time the Cat executes the bootstrap.
@@ -62,14 +62,14 @@ class CheshireCat:
 
         # bootstrap the Cat! ^._.^
 
-        # load AuthHandler
-        self.load_auth()
-
         # Start scheduling system
         self.white_rabbit = WhiteRabbit()
 
         # instantiate MadHatter (loads all plugins' hooks and tools)
-        self.mad_hatter = MadHatter()
+        self.mad_hatter = MadHatter(fastapi_app)
+
+        # load AuthHandler
+        self.load_auth()
 
         # allows plugins to do something before cat components are loaded
         self.mad_hatter.execute_hook("before_cat_bootstrap", cat=self)

--- a/core/cat/mad_hatter/decorators/__init__.py
+++ b/core/cat/mad_hatter/decorators/__init__.py
@@ -1,6 +1,6 @@
 from cat.mad_hatter.decorators.tool import CatTool, tool
 from cat.mad_hatter.decorators.hook import CatHook, hook
-from cat.mad_hatter.decorators.endpoint import CustomEndpoint, endpoint, get_endpoint, post_endpoint
+from cat.mad_hatter.decorators.endpoint import CustomEndpoint, endpoint
 from cat.mad_hatter.decorators.plugin_decorator import CatPluginDecorator, plugin
 
-__all__ = ["CatTool", "tool", "CatHook", "hook", "CustomEndpoint", "endpoint", "get_endpoint", "post_endpoint", "CatPluginDecorator", "plugin"]
+__all__ = ["CatTool", "tool", "CatHook", "hook", "CustomEndpoint", "endpoint", "CatPluginDecorator", "plugin"]

--- a/core/cat/mad_hatter/decorators/__init__.py
+++ b/core/cat/mad_hatter/decorators/__init__.py
@@ -1,5 +1,6 @@
 from cat.mad_hatter.decorators.tool import CatTool, tool
 from cat.mad_hatter.decorators.hook import CatHook, hook
+from cat.mad_hatter.decorators.endpoint import CustomEndpoint, endpoint, get_endpoint, post_endpoint
 from cat.mad_hatter.decorators.plugin_decorator import CatPluginDecorator, plugin
 
-__all__ = ["CatTool", "tool", "CatHook", "hook", "CatPluginDecorator", "plugin"]
+__all__ = ["CatTool", "tool", "CatHook", "hook", "CustomEndpoint", "endpoint", "get_endpoint", "post_endpoint", "CatPluginDecorator", "plugin"]

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -49,7 +49,12 @@ class CustomEndpoint:
             **self.kwargs,
         )
 
-        self.cheshire_cat_api.include_router(plugins_router, prefix=self.prefix)
+        try:
+            self.cheshire_cat_api.include_router(plugins_router, prefix=self.prefix)
+        except BaseException as e:
+            log.error(f"Error activating custom endpoint [{self.name}]: {e}")
+            return
+
         self.cheshire_cat_api.openapi_schema = None  # Flush the cache of openapi schema
 
         # Set the fastapi api_route into the Custom Endpoint

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -1,14 +1,14 @@
 from typing import Callable
 from fastapi import APIRouter
 
-cheshire_cat_api = None
-
 # class to represent a @endpoint
 class CustomEndpoint:
-    def __init__(self, prefix: str, path: str, function: Callable, **kwargs):
+    def __init__(self, prefix: str, path: str, function: Callable, tags, **kwargs):
         self.prefix = prefix
         self.path = path
         self.function = function
+        self.tags = tags
+
         self.name = self.prefix + self.path
 
         for k in kwargs:
@@ -17,86 +17,118 @@ class CustomEndpoint:
     def __repr__(self) -> str:
         return f"CustomEndpoint(path={self.name})"
 
-# Called from madhatter to inject the fastapi app instance
-def _init_endpoint_decorator(new_cheshire_cat_api):
-    global cheshire_cat_api
 
-    cheshire_cat_api = new_cheshire_cat_api
+class Endpoint:
 
-# @endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI operation
-def endpoint(path, methods, prefix="/custom_endpoints", tags=["custom_endpoints"], **kwargs) -> Callable:
-    """
-    Define a custom API endpoint, parameters are the same as FastAPI path operation.
-    Examples:
-        .. code-block:: python
-            @endpoint(path="/hello", methods=["GET"])
-            def my_endpoint() -> str:
-                return {"Hello":"Alice"}
-    """
+    cheshire_cat_api = None
 
-    global cheshire_cat_api
+    default_prefix = "/custom-endpoints"
+    default_tags = ["Custom Endpoints"]
 
-    def _make_endpoint(endpoint):
-        custom_endpoint = CustomEndpoint(prefix=prefix, path=path, function=endpoint, **kwargs)
+    # Called from madhatter to inject the fastapi app instance
+    def _init_decorators(cls, new_cheshire_cat_api):
+        cls.cheshire_cat_api = new_cheshire_cat_api
 
-        plugins_router = APIRouter()
-        plugins_router.add_api_route(
-            path=path, endpoint=endpoint, methods=methods, tags=tags, **kwargs
+    # @endpoint decorator. Any function in a plugin decorated by @endpoint.endpoint will be exposed as FastAPI operation
+    def endpoint(
+        cls,
+        path,
+        methods,
+        prefix=default_prefix,
+        tags=default_tags,
+        **kwargs,
+    ) -> Callable:
+        """
+        Define a custom API endpoint, parameters are the same as FastAPI path operation.
+        Examples:
+            .. code-block:: python
+                from cat.mad_hatter.decorators.endpoint import endpoint
+
+                @endpoint.endpoint(path="/hello", methods=["GET"])
+                def my_endpoint():
+                    return {"Hello":"Alice"}
+        """
+
+        def _make_endpoint(endpoint):
+            custom_endpoint = CustomEndpoint(
+                prefix=prefix, path=path, function=endpoint, tags=tags, **kwargs
+            )
+
+            plugins_router = APIRouter()
+            plugins_router.add_api_route(
+                path=path, endpoint=endpoint, methods=methods, tags=tags, **kwargs
+            )
+
+            cls.cheshire_cat_api.include_router(plugins_router, prefix=prefix)
+
+            return custom_endpoint
+
+        return _make_endpoint
+
+    # @get_endpoint decorator. Any function in a plugin decorated by @endpoint.get will be exposed as FastAPI GET operation
+    def get(
+        cls,
+        path,
+        prefix=default_prefix,
+        response_model=None,
+        tags=default_tags,
+        **kwargs,
+    ) -> Callable:
+        """
+        Define a custom API endpoint for GET operation, parameters are the same as FastAPI path operation.
+        Examples:
+            .. code-block:: python
+                from cat.mad_hatter.decorators.endpoint import endpoint
+
+                @endpoint.get(path="/hello")
+                def my_get_endpoint():
+                    return {"Hello":"Alice"}
+        """
+
+        return cls.endpoint(
+            path=path,
+            methods=["GET"],
+            prefix=prefix,
+            response_model=response_model,
+            tags=tags,
+            **kwargs,
         )
 
-        cheshire_cat_api.include_router(plugins_router, prefix=prefix)
-
-        return custom_endpoint
-
-    return _make_endpoint
-
-# @get_endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI GET operation
-def get_endpoint(
-    path, prefix="/custom_endpoints", response_model=None, tags=["custom_endpoints"], **kwargs
-) -> Callable:
-    """
-    Define a custom API endpoint for GET operation, parameters are the same as FastAPI path operation.
-    Examples:
-        .. code-block:: python
-            @get_endpoint(path="/hello")
-            def my_get_endpoint() -> str:
-                return {"Hello":"Alice"}
-    """
-
-    return endpoint(
-        path=path,
-        methods=["GET"],
-        prefix=prefix,
-        response_model=response_model,
-        tags=tags,
+    # @post_endpoint decorator. Any function in a plugin decorated by @endpoint.post will be exposed as FastAPI POST operation
+    def post(
+        cls,
+        path,
+        prefix=default_prefix,
+        response_model=None,
+        tags=default_tags,
         **kwargs,
-    )
+    ) -> Callable:
+        """
+        Define a custom API endpoint for POST operation, parameters are the same as FastAPI path operation.
+        Examples:
+            .. code-block:: python
 
-# @post_endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI POST operation
-def post_endpoint(
-    path, prefix="/custom_endpoints", response_model=None, tags=["custom_endpoints"], **kwargs
-) -> Callable:
+                from cat.mad_hatter.decorators.endpoint import endpoint
+                from pydantic import BaseModel
 
-    """
-    Define a custom API endpoint for POST operation, parameters are the same as FastAPI path operation.
-    Examples:
-        .. code-block:: python
+                class Item(BaseModel):
+                    name: str
+                    description: str
 
-            from pydantic import BaseModel
+                @endpoint.post(path="/hello")
+                def my_post_endpoint(item: Item):
+                    return {"Hello": item.name, "Description": item.description}
+        """
+        return cls.endpoint(
+            path=path,
+            methods=["POST"],
+            prefix=prefix,
+            response_model=response_model,
+            tags=tags,
+            **kwargs,
+        )
 
-            class Item(BaseModel):
-                name: str
-                description: str
+endpoint = None
 
-            @post_endpoint(path="/hello")
-            def my_post_endpoint(item: Item) -> str:
-                return {"Hello": item.name, "Description": item.description}
-    """
-    return endpoint(
-        path=path,
-        methods=["POST"],
-        prefix=prefix,
-        response_model=response_model,
-        tags=tags,
-        **kwargs,
-    )
+if not endpoint:
+    endpoint = Endpoint()

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -78,7 +78,7 @@ class Endpoint:
 
     cheshire_cat_api = None
 
-    default_prefix = "/custom-endpoints"
+    default_prefix = "/custom"
     default_tags = ["Custom Endpoints"]
 
     # Called from madhatter to inject the fastapi app instance

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -60,6 +60,7 @@ class Endpoint:
             )
 
             cls.cheshire_cat_api.include_router(plugins_router, prefix=prefix)
+            cls.cheshire_cat_api.openapi_schema = None # Flush the cache of openapi schema
 
             return custom_endpoint
 

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -42,7 +42,7 @@ class Endpoint:
         Define a custom API endpoint, parameters are the same as FastAPI path operation.
         Examples:
             .. code-block:: python
-                from cat.mad_hatter.decorators.endpoint import endpoint
+                from cat.mad_hatter.decorators import endpoint
 
                 @endpoint.endpoint(path="/hello", methods=["GET"])
                 def my_endpoint():
@@ -78,7 +78,7 @@ class Endpoint:
         Define a custom API endpoint for GET operation, parameters are the same as FastAPI path operation.
         Examples:
             .. code-block:: python
-                from cat.mad_hatter.decorators.endpoint import endpoint
+                from cat.mad_hatter.decorators import endpoint
 
                 @endpoint.get(path="/hello")
                 def my_get_endpoint():
@@ -108,7 +108,7 @@ class Endpoint:
         Examples:
             .. code-block:: python
 
-                from cat.mad_hatter.decorators.endpoint import endpoint
+                from cat.mad_hatter.decorators import endpoint
                 from pydantic import BaseModel
 
                 class Item(BaseModel):

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -1,0 +1,102 @@
+from typing import Callable
+from fastapi import APIRouter
+
+cheshire_cat_api = None
+
+# class to represent a @endpoint
+class CustomEndpoint:
+    def __init__(self, prefix: str, path: str, function: Callable, **kwargs):
+        self.prefix = prefix
+        self.path = path
+        self.function = function
+        self.name = self.prefix + self.path
+
+        for k in kwargs:
+            setattr(self, k, kwargs[k])
+
+    def __repr__(self) -> str:
+        return f"CustomEndpoint(path={self.name})"
+
+# Called from madhatter to inject the fastapi app instance
+def _init_endpoint_decorator(new_cheshire_cat_api):
+    global cheshire_cat_api
+
+    cheshire_cat_api = new_cheshire_cat_api
+
+# @endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI operation
+def endpoint(path, methods, prefix="/custom_endpoints", tags=["custom_endpoints"], **kwargs) -> Callable:
+    """
+    Define a custom API endpoint, parameters are the same as FastAPI path operation.
+    Examples:
+        .. code-block:: python
+            @endpoint(path="/hello", methods=["GET"])
+            def my_endpoint() -> str:
+                return {"Hello":"Alice"}
+    """
+
+    global cheshire_cat_api
+
+    def _make_endpoint(endpoint):
+        custom_endpoint = CustomEndpoint(prefix=prefix, path=path, function=endpoint, **kwargs)
+
+        plugins_router = APIRouter()
+        plugins_router.add_api_route(
+            path=path, endpoint=endpoint, methods=methods, tags=tags, **kwargs
+        )
+
+        cheshire_cat_api.include_router(plugins_router, prefix=prefix)
+
+        return custom_endpoint
+
+    return _make_endpoint
+
+# @get_endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI GET operation
+def get_endpoint(
+    path, prefix="/custom_endpoints", response_model=None, tags=["custom_endpoints"], **kwargs
+) -> Callable:
+    """
+    Define a custom API endpoint for GET operation, parameters are the same as FastAPI path operation.
+    Examples:
+        .. code-block:: python
+            @get_endpoint(path="/hello")
+            def my_get_endpoint() -> str:
+                return {"Hello":"Alice"}
+    """
+
+    return endpoint(
+        path=path,
+        methods=["GET"],
+        prefix=prefix,
+        response_model=response_model,
+        tags=tags,
+        **kwargs,
+    )
+
+# @post_endpoint decorator. Any function in a plugin decorated by @endpoint will be exposed as FastAPI POST operation
+def post_endpoint(
+    path, prefix="/custom_endpoints", response_model=None, tags=["custom_endpoints"], **kwargs
+) -> Callable:
+
+    """
+    Define a custom API endpoint for POST operation, parameters are the same as FastAPI path operation.
+    Examples:
+        .. code-block:: python
+
+            from pydantic import BaseModel
+
+            class Item(BaseModel):
+                name: str
+                description: str
+
+            @post_endpoint(path="/hello")
+            def my_post_endpoint(item: Item) -> str:
+                return {"Hello": item.name, "Description": item.description}
+    """
+    return endpoint(
+        path=path,
+        methods=["POST"],
+        prefix=prefix,
+        response_model=response_model,
+        tags=tags,
+        **kwargs,
+    )

--- a/core/cat/mad_hatter/decorators/endpoint.py
+++ b/core/cat/mad_hatter/decorators/endpoint.py
@@ -30,12 +30,14 @@ class CustomEndpoint:
 
     def activate(self, cheshire_cat_api):
 
+        log.info(f"Activating custom endpoint {self.name}...")
+
         self.cheshire_cat_api = cheshire_cat_api
 
         # Set the fastapi api_route into the Custom Endpoint
         for api_route in self.cheshire_cat_api.routes:
             if api_route.path == self.name:
-                log.error(f"There is already an endpoint with path {self.name}")
+                log.info(f"There is already an active endpoint with path {self.name}")
                 return
 
         plugins_router = APIRouter()
@@ -59,6 +61,8 @@ class CustomEndpoint:
         assert api_route.path == self.name
 
     def deactivate(self):
+
+        log.info(f"Deactivating custom endpoint {self.name}...")
 
         # Seems there is no official way to remove a route:
         # https://github.com/fastapi/fastapi/discussions/8088

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -18,7 +18,7 @@ from cat.mad_hatter.plugin_extractor import PluginExtractor
 from cat.mad_hatter.plugin import Plugin
 from cat.mad_hatter.decorators.hook import CatHook
 from cat.mad_hatter.decorators.tool import CatTool
-from cat.mad_hatter.decorators.endpoint import CustomEndpoint, _init_endpoint_decorator
+from cat.mad_hatter.decorators.endpoint import CustomEndpoint, endpoint
 
 from cat.experimental.form import CatForm
 
@@ -45,7 +45,7 @@ class MadHatter:
         self.forms: List[CatForm] = []  # list of active plugins forms
         self.endpoints: List[CustomEndpoint] = []  # list of active plugins endpoints
 
-        _init_endpoint_decorator(fastapi_app) # the endpoint decorator need the fastapi instance
+        endpoint._init_decorators(fastapi_app) # the endpoint decorators need the fastapi instance
 
         self.active_plugins: List[str] = []
 

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -18,7 +18,7 @@ from cat.mad_hatter.plugin_extractor import PluginExtractor
 from cat.mad_hatter.plugin import Plugin
 from cat.mad_hatter.decorators.hook import CatHook
 from cat.mad_hatter.decorators.tool import CatTool
-from cat.mad_hatter.decorators.endpoint import CustomEndpoint, endpoint
+from cat.mad_hatter.decorators.endpoint import CustomEndpoint
 
 from cat.experimental.form import CatForm
 

--- a/core/cat/mad_hatter/mad_hatter.py
+++ b/core/cat/mad_hatter/mad_hatter.py
@@ -35,7 +35,7 @@ class MadHatter:
     # - orders plugged in hooks by name and priority
     # - exposes functionality to the cat
 
-    def __init__(self, fastapi_app):
+    def __init__(self):
         self.plugins: Dict[str, Plugin] = {}  # plugins dictionary
 
         self.hooks: Dict[
@@ -44,8 +44,6 @@ class MadHatter:
         self.tools: List[CatTool] = []  # list of active plugins tools
         self.forms: List[CatForm] = []  # list of active plugins forms
         self.endpoints: List[CustomEndpoint] = []  # list of active plugins endpoints
-
-        endpoint._init_decorators(fastapi_app) # the endpoint decorators need the fastapi instance
 
         self.active_plugins: List[str] = []
 

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -74,7 +74,7 @@ class Plugin:
         except Exception as e:
             raise e
 
-        # Load of hooks and tools
+        # Load of hook, tools, forms and endpoints
         self._load_decorated_functions()
 
         # by default, plugin settings are saved inside the plugin folder
@@ -341,7 +341,7 @@ class Plugin:
     def _deactivate_endpoints(self):
 
         for endpoint in self._endpoints:
-            endpoint.remove()
+            endpoint.deactivate()
 
     def _clean_hook(self, hook: CatHook):
         # getmembers returns a tuple

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -100,7 +100,7 @@ class Plugin:
         self._hooks = []
         self._tools = []
         #TODO : clear of forms is missing here?
-        self._endpoints = []
+        self._deactivate_endpoints()
         self._plugin_overrides = []
         self._active = False
 
@@ -337,6 +337,11 @@ class Plugin:
         name = self.manifest.get("name")
         url = self.manifest.get("plugin_url")
         return f"To resolve any problem related to {name} plugin, contact the creator using github issue at the link {url}"
+
+    def _deactivate_endpoints(self):
+
+        for endpoint in self._endpoints:
+            endpoint.remove()
 
     def _clean_hook(self, hook: CatHook):
         # getmembers returns a tuple

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -51,7 +51,7 @@ async def get_available_plugins(
             {"name": hook.name, "priority": hook.priority} for hook in p.hooks
         ]
         manifest["tools"] = [{"name": tool.name} for tool in p.tools]
-        manifest["endpoints"] = [{"name": endpoint.name} for endpoint in p.endpoints]
+        manifest["endpoints"] = [{"name": endpoint.name, "tags": endpoint.tags} for endpoint in p.endpoints]
 
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -51,6 +51,7 @@ async def get_available_plugins(
             {"name": hook.name, "priority": hook.priority} for hook in p.hooks
         ]
         manifest["tools"] = [{"name": tool.name} for tool in p.tools]
+        manifest["endpoints"] = [{"name": endpoint.name} for endpoint in p.endpoints]
 
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]

--- a/core/cat/startup.py
+++ b/core/cat/startup.py
@@ -27,7 +27,6 @@ from cat.routes.static import admin, static
 from cat.routes.openapi import get_openapi_configuration_function
 from cat.looking_glass.cheshire_cat import CheshireCat
 
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
 
@@ -35,10 +34,10 @@ async def lifespan(app: FastAPI):
     #
     # loads Cat and plugins
     # Every endpoint can access the cat instance via request.app.state.ccat
-    # - Not using midlleware because I can't make it work with both http and websocket;
+    # - Not using middleware because I can't make it work with both http and websocket;
     # - Not using Depends because it only supports callables (not instances)
     # - Starlette allows this: https://www.starlette.io/applications/#storing-state-on-the-app-instance
-    app.state.ccat = CheshireCat()
+    app.state.ccat = CheshireCat(cheshire_cat_api)
 
     # Dict of pseudo-sessions (key is the user_id)
     app.state.strays = {}

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -21,6 +21,8 @@ from cat.mad_hatter.plugin import Plugin
 from cat.startup import cheshire_cat_api
 from tests.utils import create_mock_plugin_zip
 
+from cat.mad_hatter.mad_hatter import MadHatter
+
 import time
 
 FAKE_TIMESTAMP = 1705855981
@@ -163,3 +165,18 @@ def patch_time_now(monkeypatch):
         return FAKE_TIMESTAMP
 
     monkeypatch.setattr(time, 'time', mytime)
+
+#fixture for mad hatter with mock plugin installed
+@pytest.fixture
+def mad_hatter_with_mock_plugin(client):  # client here injects the monkeypatched version of the cat
+
+    # each test is given the mad_hatter instance (it's a singleton)
+    mad_hatter = MadHatter()
+
+    # install plugin
+    new_plugin_zip_path = create_mock_plugin_zip(flat=True)
+    mad_hatter.install_plugin(new_plugin_zip_path)
+
+    yield mad_hatter
+
+    mad_hatter.uninstall_plugin("mock_plugin")

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -1,28 +1,8 @@
-import pytest
-
-from cat.mad_hatter.mad_hatter import MadHatter
 from cat.mad_hatter.decorators import CustomEndpoint
 
-from tests.utils import create_mock_plugin_zip
+def test_endpoints_discovery(mad_hatter_with_mock_plugin):
 
-# this function will be run before each test function
-@pytest.fixture
-def mad_hatter(client):  # client here injects the monkeypatched version of the cat
-
-    # each test is given the mad_hatter instance (it's a singleton)
-    mad_hatter = MadHatter()
-
-    # install plugin
-    new_plugin_zip_path = create_mock_plugin_zip(flat=True)
-    mad_hatter.install_plugin(new_plugin_zip_path)
-
-    yield mad_hatter
-
-    mad_hatter.uninstall_plugin("mock_plugin")
-
-
-def test_endpoints_discovery(mad_hatter):
-    mock_plugin_endpoints = mad_hatter.plugins["mock_plugin"].endpoints
+    mock_plugin_endpoints = mad_hatter_with_mock_plugin.plugins["mock_plugin"].endpoints
 
     assert len(mock_plugin_endpoints) == 4
 
@@ -37,7 +17,7 @@ def test_endpoints_discovery(mad_hatter):
             assert h.tags == ["Tests"]
 
 
-def test_endpoint_decorator(client, mad_hatter):
+def test_endpoint_decorator(client, mad_hatter_with_mock_plugin):
 
     response = client.get("/custom-endpoints/endpoint")
 
@@ -46,7 +26,7 @@ def test_endpoint_decorator(client, mad_hatter):
     assert response.json()["result"] == "endpoint default prefix"
 
 
-def test_endpoint_decorator_prefix(client, mad_hatter):
+def test_endpoint_decorator_prefix(client, mad_hatter_with_mock_plugin):
 
     response = client.get("/tests/endpoint")
 
@@ -55,7 +35,7 @@ def test_endpoint_decorator_prefix(client, mad_hatter):
     assert response.json()["result"] == "endpoint prefix tests"
 
 
-def test_get_endpoint(client, mad_hatter):
+def test_get_endpoint(client, mad_hatter_with_mock_plugin):
 
     response = client.get("/tests/get")
 
@@ -65,7 +45,7 @@ def test_get_endpoint(client, mad_hatter):
     assert response.json()["stray_user_id"] == "user"
 
 
-def test_post_endpoint(client, mad_hatter):
+def test_post_endpoint(client, mad_hatter_with_mock_plugin):
 
     payload = {"name": "the cat", "description" : "it's magic"}
     response = client.post("/tests/post", json=payload)
@@ -75,12 +55,12 @@ def test_post_endpoint(client, mad_hatter):
     assert response.json()["name"] == "the cat"
     assert response.json()["description"] == "it's magic"
 
-def test_plugin_deactivation(client, mad_hatter):
+def test_plugin_deactivation(client, mad_hatter_with_mock_plugin):
 
     response = client.get("/custom-endpoints/endpoint")
     assert response.status_code == 200
 
-    mad_hatter.toggle_plugin("mock_plugin")
+    mad_hatter_with_mock_plugin.toggle_plugin("mock_plugin")
 
     response = client.get("/custom-endpoints/endpoint")
     assert response.status_code == 404

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -28,10 +28,16 @@ def test_endpoints_discovery(mad_hatter):
         assert isinstance(h, CustomEndpoint)
         assert h.plugin_id == "mock_plugin"
 
+        if h.name == "/custom-endpoints/endpoint":
+            assert h.tags == ["Custom Endpoints"]
+
+        if h.name == "/custom-endpoints/tests":
+            assert h.tags == ["Tests"]
+
 
 def test_endpoint_decorator(client):
 
-    response = client.get("/custom_endpoints/endpoint")
+    response = client.get("/custom-endpoints/endpoint")
 
     assert response.status_code == 200
     

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -18,6 +18,8 @@ def mad_hatter(client):  # client here injects the monkeypatched version of the 
 
     yield mad_hatter
 
+    mad_hatter.uninstall_plugin("mock_plugin")
+
 
 def test_endpoints_discovery(mad_hatter):
     mock_plugin_endpoints = mad_hatter.plugins["mock_plugin"].endpoints
@@ -35,7 +37,7 @@ def test_endpoints_discovery(mad_hatter):
             assert h.tags == ["Tests"]
 
 
-def test_endpoint_decorator(client):
+def test_endpoint_decorator(client, mad_hatter):
 
     response = client.get("/custom-endpoints/endpoint")
 
@@ -44,7 +46,7 @@ def test_endpoint_decorator(client):
     assert response.json()["result"] == "endpoint default prefix"
 
 
-def test_endpoint_decorator_prefix(client):
+def test_endpoint_decorator_prefix(client, mad_hatter):
 
     response = client.get("/tests/endpoint")
 
@@ -53,7 +55,7 @@ def test_endpoint_decorator_prefix(client):
     assert response.json()["result"] == "endpoint prefix tests"
 
 
-def test_get_endpoint(client):
+def test_get_endpoint(client, mad_hatter):
 
     response = client.get("/tests/get")
 
@@ -63,7 +65,7 @@ def test_get_endpoint(client):
     assert response.json()["stray_user_id"] == "user"
 
 
-def test_post_endpoint(client):
+def test_post_endpoint(client, mad_hatter):
 
     payload = {"name": "the cat", "description" : "it's magic"}
     response = client.post("/tests/post", json=payload)

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -10,16 +10,16 @@ def test_endpoints_discovery(mad_hatter_with_mock_plugin):
         assert isinstance(h, CustomEndpoint)
         assert h.plugin_id == "mock_plugin"
 
-        if h.name == "/custom-endpoints/endpoint":
+        if h.name == "/custom/endpoint":
             assert h.tags == ["Custom Endpoints"]
 
-        if h.name == "/custom-endpoints/tests":
+        if h.name == "/custom/tests":
             assert h.tags == ["Tests"]
 
 
 def test_endpoint_decorator(client, mad_hatter_with_mock_plugin):
 
-    response = client.get("/custom-endpoints/endpoint")
+    response = client.get("/custom/endpoint")
 
     assert response.status_code == 200
     
@@ -57,10 +57,10 @@ def test_post_endpoint(client, mad_hatter_with_mock_plugin):
 
 def test_plugin_deactivation(client, mad_hatter_with_mock_plugin):
 
-    response = client.get("/custom-endpoints/endpoint")
+    response = client.get("/custom/endpoint")
     assert response.status_code == 200
 
     mad_hatter_with_mock_plugin.toggle_plugin("mock_plugin")
 
-    response = client.get("/custom-endpoints/endpoint")
+    response = client.get("/custom/endpoint")
     assert response.status_code == 404

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -1,0 +1,68 @@
+import pytest
+
+from cat.mad_hatter.mad_hatter import MadHatter
+from cat.mad_hatter.decorators import CustomEndpoint
+
+from tests.utils import create_mock_plugin_zip
+
+# this function will be run before each test function
+@pytest.fixture
+def mad_hatter(client):  # client here injects the monkeypatched version of the cat
+
+    # each test is given the mad_hatter instance (it's a singleton)
+    mad_hatter = MadHatter()
+
+    # install plugin
+    new_plugin_zip_path = create_mock_plugin_zip(flat=True)
+    mad_hatter.install_plugin(new_plugin_zip_path)
+
+    yield mad_hatter
+
+
+def test_endpoints_discovery(mad_hatter):
+    mock_plugin_endpoints = mad_hatter.plugins["mock_plugin"].endpoints
+
+    assert len(mock_plugin_endpoints) == 4
+
+    for h in mock_plugin_endpoints:
+        assert isinstance(h, CustomEndpoint)
+        assert h.plugin_id == "mock_plugin"
+
+
+def test_endpoint_decorator(client):
+
+    response = client.get("/custom_endpoints/endpoint")
+
+    assert response.status_code == 200
+    
+    assert response.json()["result"] == "endpoint default prefix"
+
+
+def test_endpoint_decorator_prefix(client):
+
+    response = client.get("/tests/endpoint")
+
+    assert response.status_code == 200
+    
+    assert response.json()["result"] == "endpoint prefix tests"
+
+
+def test_get_endpoint(client):
+
+    response = client.get("/tests/get")
+
+    assert response.status_code == 200
+    
+    assert response.json()["result"] == "ok"
+    assert response.json()["stray_user_id"] == "user"
+
+
+def test_post_endpoint(client):
+
+    payload = {"name": "the cat", "description" : "it's magic"}
+    response = client.post("/tests/post", json=payload)
+
+    assert response.status_code == 200
+
+    assert response.json()["name"] == "the cat"
+    assert response.json()["description"] == "it's magic"

--- a/core/tests/mad_hatter/test_endpoints.py
+++ b/core/tests/mad_hatter/test_endpoints.py
@@ -72,3 +72,13 @@ def test_post_endpoint(client):
 
     assert response.json()["name"] == "the cat"
     assert response.json()["description"] == "it's magic"
+
+def test_plugin_deactivation(client, mad_hatter):
+
+    response = client.get("/custom-endpoints/endpoint")
+    assert response.status_code == 200
+
+    mad_hatter.toggle_plugin("mock_plugin")
+
+    response = client.get("/custom-endpoints/endpoint")
+    assert response.status_code == 404

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -54,6 +54,7 @@ def test_create_plugin(plugin):
     # hooks and tools
     assert plugin.hooks == []
     assert plugin.tools == []
+    assert plugin.endpoints == []
 
 
 def test_activate_plugin(plugin):

--- a/core/tests/mad_hatter/test_plugin.py
+++ b/core/tests/mad_hatter/test_plugin.py
@@ -94,12 +94,19 @@ def test_activate_plugin(plugin):
     assert "mock tool example 2" in tool.start_examples
 
 
-def test_deactivate_plugin(plugin):
-    # The plugin is non active by default
-    plugin.activate()
+def test_deactivate_plugin(mad_hatter_with_mock_plugin):
+    
+    # The plugin is installed and activated by the mad_hatter_with_mock_plugin fixture
+    
+    # Get the reference to the mock plugin
+    plugin = mad_hatter_with_mock_plugin.plugins["mock_plugin"]
 
-    # deactivate it
-    plugin.deactivate()
+    # Deactivate the mock plugin
+    # Why not using plugin.deactivate()? 
+    # the "endpoint" decorator needs the reference to the FastAPI app instance for endpoint removing.
+    # Calling plugin.deactivate() the method CustomEndpoint.deactivate() raises the exception:
+    # "self.cheshire_cat_api is None"
+    mad_hatter_with_mock_plugin.toggle_plugin("mock_plugin")
 
     assert plugin.active is False
 

--- a/core/tests/mocks/mock_plugin/mock_endpoint.py
+++ b/core/tests/mocks/mock_plugin/mock_endpoint.py
@@ -1,7 +1,7 @@
 from fastapi import Request, Depends
 from pydantic import BaseModel
 
-from cat.mad_hatter.decorators import endpoint, get_endpoint, post_endpoint
+from cat.mad_hatter.decorators import endpoint
 from cat.auth.connection import HTTPAuth
 from cat.auth.permissions import AuthPermission, AuthResource
 
@@ -9,18 +9,18 @@ class Item(BaseModel):
     name: str
     description: str
 
-@endpoint(path="/endpoint", methods=["GET"], tags=["Tests"])
+@endpoint.endpoint(path="/endpoint", methods=["GET"])
 def test_endpoint():
     return {"result":"endpoint default prefix"}
 
-@endpoint(path="/endpoint", prefix="/tests", methods=["GET"], tags=["Tests"])
+@endpoint.endpoint(path="/endpoint", prefix="/tests", methods=["GET"], tags=["Tests"])
 def test_endpoint_prefix():
     return {"result":"endpoint prefix tests"}
 
-@get_endpoint(path="/get", prefix="/tests", tags=["Tests"])
+@endpoint.get(path="/get", prefix="/tests", tags=["Tests"])
 def test_get(request: Request, stray=Depends(HTTPAuth(AuthResource.PLUGINS, AuthPermission.LIST))):
     return {"result":"ok", "stray_user_id":stray.user_id}
 
-@post_endpoint(path="/post", prefix="/tests", tags=["Tests"])
+@endpoint.post(path="/post", prefix="/tests", tags=["Tests"])
 def test_post(item: Item) -> str:
     return {"name": item.name, "description": item.description}

--- a/core/tests/mocks/mock_plugin/mock_endpoint.py
+++ b/core/tests/mocks/mock_plugin/mock_endpoint.py
@@ -1,0 +1,26 @@
+from fastapi import Request, Depends
+from pydantic import BaseModel
+
+from cat.mad_hatter.decorators import endpoint, get_endpoint, post_endpoint
+from cat.auth.connection import HTTPAuth
+from cat.auth.permissions import AuthPermission, AuthResource
+
+class Item(BaseModel):
+    name: str
+    description: str
+
+@endpoint(path="/endpoint", methods=["GET"], tags=["Tests"])
+def test_endpoint():
+    return {"result":"endpoint default prefix"}
+
+@endpoint(path="/endpoint", prefix="/tests", methods=["GET"], tags=["Tests"])
+def test_endpoint_prefix():
+    return {"result":"endpoint prefix tests"}
+
+@get_endpoint(path="/get", prefix="/tests", tags=["Tests"])
+def test_get(request: Request, stray=Depends(HTTPAuth(AuthResource.PLUGINS, AuthPermission.LIST))):
+    return {"result":"ok", "stray_user_id":stray.user_id}
+
+@post_endpoint(path="/post", prefix="/tests", tags=["Tests"])
+def test_post(item: Item) -> str:
+    return {"name": item.name, "description": item.description}


### PR DESCRIPTION
# Description

New decorators to permit the creation of custom endpoints:
``` python
from cat.mad_hatter.decorators import endpoint

@endpoint.get
@endpoint.post
@endpoint.endpoint (for all the other HTTP verbs)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Automatic tests implemented

# Simple example of use inside a plugin
``` python
from cat.mad_hatter.decorators import endpoint

@endpoint.get(path="/hello")
def hello_world():
    return {"Hello":"world"}
```

Consume with:
`curl http://localhost:1865/custom/hello`

# More complex example
``` python
from cat.mad_hatter.decorators import endpoint
from pydantic import BaseModel

class Item(BaseModel):
    name: str
    description: str

@endpoint.post(path="/hello", prefix="/example", tags=["Custom Tag"])
def my_post_endpoint(item: Item, stray=Depends(HTTPAuth(AuthResource.PLUGINS, AuthPermission.LIST))):
    return {"Hello": item.name, "Description": item.description, "Stray user": stray.user_id}
```

Consume with:
``` shell
curl --request POST \
  --url http://localhost:1865/example/hello \
  --header 'Content-Type: application/json' \
  --data '{
  "name": "the Cat",
  "description": "is magic!"
}'
```

# Internals
The decorators wrap the function as a FastAPI path operation, all the FastAPI path operation parameters can be used.
The default prefix is `custom` and default tag is `Custom Endpoints`

The new decorators are managed as other decorators (approach was: searched everywhere for `hook` and adapted for `endpoint`).

## Activation and deactivation of plugins
- During activation we have to do just a trick to flush the openapi schema cache for `/docs`
- During deactivate we have to remove the FastAPI route manually, seems there is no official method to remove them, see https://github.com/fastapi/fastapi/discussions/8088, we have also to flush the openapi schema cache for `/docs` too

## Change to startup process
Note, __there is a change in the CheshireCat startup process__, now the CheshireCat needs the FastAPI app instance, why?

The `endpoint` decorator creates a new FastAPI router for each new custom endpoint and then includes the router in the FastAPI app, CheshireCat activate the decorator injecting the FastAPI app.

## Flows

### Startup process
- CheshireCat starts MadHatter initialization
- MadHatter finds and loads all the plugins
- MadHatter activate all the plugins however at this steps the endpoints decorators are not "activated", the custom routers are not included in FastAPI app yet
- `MadHatter.find_plugins()` calls the CheshireCat callback `on_finish_plugins_sync_callback`
- In the callback CheshireCat all the endpoints of active plugins get activated
- The callback calls `Endpoint.activate()` for each custom endpoint
- `Endpoint.activate()` add the route to the FastAPI routes and clear the `/docs` cache

### Plugin installation process
- User installs a plugin
- MadHatter install the plugin
- MadHatter calls `toggle_plugin()`
- `toggle_plugin()` activates the plugin (however the endpoints are not really active, are not yet included in FastAPI app)
- `toggle_plugin()` calls the CheshireCat callback `on_finish_plugins_sync_callback`
- The callback calls `Endpoint.activate()` for each custom endpoint
- `Endpoint.activate()` add the route to the FastAPI routes and clear the `/docs` cache

### Plugin activation process
- User activates a plugin
- `toggle_plugin()` activates the plugin (however the endpoints are not really active, are not yet included in FastAPI app)
- `toggle_plugin()` calls the CheshireCat callback `on_finish_plugins_sync_callback`
- The callback calls `Endpoint.activate()` for each custom endpoint
- `Endpoint.activate()` add the route to the FastAPI routes and clear the `/docs` cache

### Plugin deactivation process
- User activates a plugin
- `toggle_plugin()` deactivate the plugin
- `Plugin.deactivate()` calls `Endpoint.deactivate()` for each custom endpoint related to the plugin
- `Endpoint.deactivate()` removes the route from the FastAPI routes and clear the `/docs` cache
- `toggle_plugin()` calls the CheshireCat callback `on_finish_plugins_sync_callback`
- The callback do nothing about endpoint decorator


# Plugins API
The endpoints are already exposed by the `/plugins/` API (can be shown in the admin portal).
This is an example of the returned payload with the new `endpoints` node:
``` json
{
   "installed": [
            "id": "cc-dot-commands",
            "name": "Dot Commands",
            "description": "Handy utility designed to simplify and speed up your plugin development process. Install it, activate it, and send a message with just a period '.' in the chat",
            "author_name": "sambarza@gmail.com",
            "hooks": [...],
            "tools": [...],
            "endpoints": [
                {
                    "name": "/example/hello",
                    "tags": [
                        "Dot Commands"
                    ]
                }
            ]
        }
]
```

# Automatic tests
`test_endpoints.py` tests the new decorators.