### PR TITLE
chore: plugin compatibility infos

### DIFF
--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -241,6 +241,16 @@ class Plugin:
         meta["thumb"] = json_file_data.get("thumb", "")
         meta["version"] = json_file_data.get("version", "0.0.1")
 
+        # Core compatibility
+        compatibility = json_file_data.get(
+            "compatibility",
+            {
+                "min_version": "not specified",
+                "max_version": "not specified",
+            },
+        )
+        meta["compatibility"] = compatibility
+
         return meta
 
     def _install_requirements(self):

--- a/core/cat/mad_hatter/plugin.py
+++ b/core/cat/mad_hatter/plugin.py
@@ -240,16 +240,8 @@ class Plugin:
         meta["tags"] = json_file_data.get("tags", "unknown")
         meta["thumb"] = json_file_data.get("thumb", "")
         meta["version"] = json_file_data.get("version", "0.0.1")
-
-        # Core compatibility
-        compatibility = json_file_data.get(
-            "compatibility",
-            {
-                "min_version": "not specified",
-                "max_version": "not specified",
-            },
-        )
-        meta["compatibility"] = compatibility
+        meta["min_cat_version"] = json_file_data.get("min_cat_version", "")
+        meta["max_cat_version"] = json_file_data.get("max_cat_version", "")
 
         return meta
 


### PR DESCRIPTION
# Description

Added min and max version on plugin manifest. 
If we agree on the structure I'll update admin-vue and ts-client (Plugin.ts type)

We want to enforce it? e.g. on plugin installation or activation (Not necessary for me)

Related to issue #960 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
