### PR TITLE
Forms model getter

### DIFF
--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -223,7 +223,7 @@ JSON:
         # JSON structure
         # BaseModel.__fields__['my_field'].type_
         JSON_structure = "{"
-        for field_name, field in self.model_class.model_fields.items():
+        for field_name, field in self.model_getter().model_fields.items():
             if field.description:
                 description = field.description
             else:
@@ -272,7 +272,7 @@ Updated JSON:
             # INFO TODO: In this case the optional fields are always ignored
 
             # Attempts to create the model object to update the default values and validate it
-            model = self.model_class(**model).model_dump(mode="json")
+            model = self.model_getter()(**model).model_dump(mode="json")
 
             # If model is valid change state to COMPLETE
             self._state = CatFormState.COMPLETE

--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -34,10 +34,14 @@ class CatForm:  # base model of forms
 
         self._errors: List[str] = []
         self._missing_fields: List[str] = []
+        self.model_class = self.model_getter()
 
     @property
     def cat(self):
         return self._cat
+
+    def model_getter(self):
+        return self.model_class
 
     def submit(self, form_data) -> str:
         raise NotImplementedError

--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -34,7 +34,6 @@ class CatForm:  # base model of forms
 
         self._errors: List[str] = []
         self._missing_fields: List[str] = []
-        self.model_class = self.model_getter()
 
     @property
     def cat(self):

--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -128,7 +128,7 @@ JSON:
         # If the state is INCOMPLETE, execute model update
         # (and change state based on validation result)
         if self._state == CatFormState.INCOMPLETE:
-            self._model = self.update()
+            self.update()
 
         # If state is COMPLETE, ask confirm (or execute action directly)
         if self._state == CatFormState.COMPLETE:
@@ -149,12 +149,11 @@ JSON:
         json_details = self.sanitize(json_details)
 
         # model merge old and new
-        new_model = self._model | json_details
+        self._model = self._model | json_details
 
         # Validate new_details
-        new_model = self.validate(new_model)
+        self.validate()
 
-        return new_model
 
     def message(self):
         state_methods = {
@@ -264,7 +263,7 @@ Updated JSON:
         return model
 
     # Validate model
-    def validate(self, model):
+    def validate(self):
         self._missing_fields = []
         self._errors = []
 
@@ -272,7 +271,7 @@ Updated JSON:
             # INFO TODO: In this case the optional fields are always ignored
 
             # Attempts to create the model object to update the default values and validate it
-            model = self.model_getter()(**model).model_dump(mode="json")
+            self.model_getter()(**self._model).model_dump(mode="json")
 
             # If model is valid change state to COMPLETE
             self._state = CatFormState.COMPLETE
@@ -285,9 +284,7 @@ Updated JSON:
                     self._missing_fields.append(field_name)
                 else:
                     self._errors.append(f'{field_name}: {error_message["msg"]}')
-                    del model[field_name]
+                    del self._model[field_name]
 
             # Set state to INCOMPLETE
             self._state = CatFormState.INCOMPLETE
-
-        return model


### PR DESCRIPTION
# Description

I'll try this even if it had not that much success.

This PR to add the `model_getter` feature to the conversational forms. Basically, it is a straightforward method to allow developers define the extraction schema in a dynamic way. This opens the way for so many use cases: multi tenant app with schema based on the tenant, schemas dynamically load from an external source that might change frequently, schema that changes dynamically based on the information gathered in the previous round of the form (this one is pretty cool), etc. 

Here's an example of that:

```python

class PizzaOrder(BaseModel):
    pizza_type: str
    phone: int
    address: str

class PepperoniPizza(PizzaOrder):
    with_extra_cheese: bool

@form
class PizzaForm(CatForm):
    description = "Pizza Order"
    model_class = PizzaOrder
    start_examples = [
        "order a pizza!",
        "I want pizza"
    ]
    stop_examples = [
        "stop pizza order",
        "not hungry anymore",
    ]
    ask_confirm = True

    def model_getter(self):
        if "pizza_type" in self._model and self._model["pizza_type"] == "pepperoni":
            self.model_class = PepperoniPizza
        return self.model_class

    def submit(self, form_data):
        return {
            "output": f"Pizza order on its way: {form_data}"
        }

```

In action:


![image](https://github.com/user-attachments/assets/dd64aa59-4d62-4f03-b7bd-f28970346b2f)

I needed to refactor the `update` and `validate` methods since they were a lil bit messy and were blocking the full potential of the `model_getter` on validation, which otherwise would have used the model_class from the previous form round.

Hope you like this!

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
