### PR TITLE
Add PUT Endpoint for Updating Single Point by ID

### DIFF
--- a/core/cat/routes/memory/points.py
+++ b/core/cat/routes/memory/points.py
@@ -277,7 +277,7 @@ async def edit_memory_point(
     collection_id: str,
     point_id: str,
     point: MemoryPointBase,
-    stray: StrayCat = Depends(HTTPAuth(AuthResource.MEMORY, AuthPermission.WRITE)),
+    stray: StrayCat = Depends(HTTPAuth(AuthResource.MEMORY, AuthPermission.EDIT)),
 ) -> MemoryPoint:
     """Edit a point in memory
 
@@ -334,7 +334,7 @@ async def edit_memory_point(
     points = vector_memory.collections[collection_id].get_points([point_id])
     if points is None or len(points) == 0:
         raise HTTPException(
-            status_code=400, detail={"error": f"Point with id {point_id} does not exist."}
+            status_code=400, detail={"error": f"Point does not exist."}
         )
 
     # embed content

--- a/core/tests/routes/memory/test_memory_points.py
+++ b/core/tests/routes/memory/test_memory_points.py
@@ -316,7 +316,7 @@ def test_edit_point_wrong_collection_and_not_exist(client):
         "/memory/collections/declarative/points/{point_id}", json=req_json
     )
     assert res.status_code == 400
-    assert "Point with id {point_id} does not exist." in res.json()["detail"]["error"]
+    assert f"Point does not exist." in res.json()["detail"]["error"]
 
 
 


### PR DESCRIPTION
# Description


This PR adds a new PUT endpoint to update a single memory point in a collection using the Qdrant point ID.

With existing GET and DELETE endpoints for single points, this completes the CRUD operations.

Example of usage:
```
content = "MIAO!"
metadata = {"custom_key": "new_custom_value"}
req_json = {
    "content": content,
    "metadata": metadata,
}

# edit the point
res = requests.put(
    f"http://localhost:1865/memory/collections/{collection}/points/{point_id}", json=req_json
)
json = res.json()
print(json)
```

Related to issue #897

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
