### PR TITLE
Back to sync in auth handlers

### DIFF
--- a/core/cat/auth/connection.py
+++ b/core/cat/auth/connection.py
@@ -41,7 +41,7 @@ class ConnectionAuth(ABC):
         # get protocol from Starlette request
         protocol = connection.scope.get('type')
         # extract credentials (user_id, token_or_key) from connection
-        user_id, credential = await self.extract_credentials(connection)
+        user_id, credential = self.extract_credentials(connection)
         auth_handlers = [
             # try to get user from local idp
             connection.app.state.ccat.core_auth_handler,
@@ -49,7 +49,7 @@ class ConnectionAuth(ABC):
             connection.app.state.ccat.custom_auth_handler,
         ]
         for ah in auth_handlers:
-            user: AuthUserInfo = await ah.authorize_user_from_credential(
+            user: AuthUserInfo = ah.authorize_user_from_credential(
                 protocol, credential, self.resource, self.permission, user_id=user_id
             )
             if user:
@@ -59,7 +59,7 @@ class ConnectionAuth(ABC):
         self.not_allowed(connection)
 
     @abstractmethod
-    async def extract_credentials(self, connection: Request | WebSocket) -> Tuple[str] | None:
+    def extract_credentials(self, connection: Request | WebSocket) -> Tuple[str] | None:
         pass
 
     @abstractmethod
@@ -73,7 +73,7 @@ class ConnectionAuth(ABC):
 
 class HTTPAuth(ConnectionAuth):
 
-    async def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
+    def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
         """
         Extract user_id and token/key from headers
         """
@@ -121,7 +121,7 @@ class HTTPAuth(ConnectionAuth):
 
 class WebSocketAuth(ConnectionAuth):
 
-    async def extract_credentials(self, connection: WebSocket) -> Tuple[str, str] | None:
+    def extract_credentials(self, connection: WebSocket) -> Tuple[str, str] | None:
         """
         Extract user_id from WebSocket path params
         Extract token from WebSocket query string
@@ -166,7 +166,7 @@ class WebSocketAuth(ConnectionAuth):
 
 class CoreFrontendAuth(HTTPAuth):
 
-    async def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
+    def extract_credentials(self, connection: Request) -> Tuple[str, str] | None:
         """
         Extract user_id from cookie
         """

--- a/core/cat/factory/custom_auth_handler.py
+++ b/core/cat/factory/custom_auth_handler.py
@@ -20,7 +20,7 @@ class BaseAuthHandler(ABC):  # TODOAUTH: pydantic model?
     MUST be implemented by subclasses.
     """
 
-    async def authorize_user_from_credential(
+    def authorize_user_from_credential(
         self,
         protocol: Literal["http", "websocket"],
         credential: str,
@@ -32,17 +32,17 @@ class BaseAuthHandler(ABC):  # TODOAUTH: pydantic model?
     ) -> AuthUserInfo | None:
         if is_jwt(credential):
             # JSON Web Token auth
-            return await self.authorize_user_from_jwt(
+            return self.authorize_user_from_jwt(
                 credential, auth_resource, auth_permission
             )
         else:
             # API_KEY auth
-            return await self.authorize_user_from_key(
+            return self.authorize_user_from_key(
                 protocol, user_id, credential, auth_resource, auth_permission
             )
 
     @abstractmethod
-    async def authorize_user_from_jwt(
+    def authorize_user_from_jwt(
         self,
         token: str,
         auth_resource: AuthResource,
@@ -52,7 +52,7 @@ class BaseAuthHandler(ABC):  # TODOAUTH: pydantic model?
         pass
 
     @abstractmethod
-    async def authorize_user_from_key(
+    def authorize_user_from_key(
         self,
         protocol: Literal["http", "websocket"],
         user_id: str,
@@ -67,7 +67,7 @@ class BaseAuthHandler(ABC):  # TODOAUTH: pydantic model?
 # Core auth handler, verify token on local idp
 class CoreAuthHandler(BaseAuthHandler):
 
-    async def authorize_user_from_jwt(
+    def authorize_user_from_jwt(
         self, token: str, auth_resource: AuthResource, auth_permission: AuthPermission
     ) -> AuthUserInfo | None:
         try:
@@ -98,7 +98,7 @@ class CoreAuthHandler(BaseAuthHandler):
         # do not pass
         return None
 
-    async def authorize_user_from_key(
+    def authorize_user_from_key(
             self,
             protocol: Literal["http", "websocket"],
             user_id: str,
@@ -147,7 +147,7 @@ class CoreAuthHandler(BaseAuthHandler):
         # No match -> deny access
         return None
 
-    async def issue_jwt(self, username: str, password: str) -> str | None:
+    def issue_jwt(self, username: str, password: str) -> str | None:
         # authenticate local user credentials and return a JWT token
 
         # brutal search over users, which are stored in a simple dictionary.
@@ -178,10 +178,10 @@ class CoreAuthHandler(BaseAuthHandler):
 
 # Default Auth, always deny auth by default (only core auth decides).
 class CoreOnlyAuthHandler(BaseAuthHandler):
-    async def authorize_user_from_jwt(*args, **kwargs) -> AuthUserInfo | None:
+    def authorize_user_from_jwt(*args, **kwargs) -> AuthUserInfo | None:
         return None
 
-    async def authorize_user_from_key(*args, **kwargs) -> AuthUserInfo | None:
+    def authorize_user_from_key(*args, **kwargs) -> AuthUserInfo | None:
         return None
 
 

--- a/core/cat/routes/auth.py
+++ b/core/cat/routes/auth.py
@@ -29,7 +29,7 @@ async def core_login_token(request: Request, response: Response):
 
     # use username and password to authenticate user from local identity provider and get token
     auth_handler = request.app.state.ccat.core_auth_handler
-    access_token = await auth_handler.issue_jwt(
+    access_token = auth_handler.issue_jwt(
         form_data["username"], form_data["password"]
     )
 
@@ -95,7 +95,7 @@ async def auth_token(request: Request, credentials: UserCredentials):
 
     # use username and password to authenticate user from local identity provider and get token
     auth_handler = request.app.state.ccat.core_auth_handler
-    access_token = await auth_handler.issue_jwt(
+    access_token = auth_handler.issue_jwt(
         credentials.username, credentials.password
     )
 

--- a/core/tests/routes/auth/test_jwt.py
+++ b/core/tests/routes/auth/test_jwt.py
@@ -33,8 +33,7 @@ def test_refuse_issue_jwt(client):
     assert json["detail"]["error"] == "Invalid Credentials"
 
 
-@pytest.mark.asyncio  # to test async functions
-async def test_issue_jwt(client):
+def test_issue_jwt(client):
     creds = {
         "username": "admin",
         "password": "admin"
@@ -49,7 +48,7 @@ async def test_issue_jwt(client):
 
     # is the JWT correct for core auth handler?
     auth_handler = client.app.state.ccat.core_auth_handler
-    user_info = await auth_handler.authorize_user_from_jwt(
+    user_info = auth_handler.authorize_user_from_jwt(
         received_token, AuthResource.LLM, AuthPermission.WRITE
     )
     assert len(user_info.id) == 36 and len(user_info.id.split("-")) == 5 # uuid4

--- a/core/tests/routes/auth/test_jwt.py
+++ b/core/tests/routes/auth/test_jwt.py
@@ -69,8 +69,7 @@ def test_issue_jwt(client):
         assert False
 
 
-@pytest.mark.asyncio
-async def test_issue_jwt_for_new_user(client):
+def test_issue_jwt_for_new_user(client):
 
     # create new user
     creds = {


### PR DESCRIPTION
# Description

Removed `async` stuff from `BaseAuthHandler`  and other methods that were not using real async stuff. This is a breaking change since async custom auth handlers implementation needs to migrate to sync one. 

Will update docs and blog after merging it in main.

Related to issue #958 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
