### PR TITLE
Add New POST Endpoint /memory/recall

### DIFF
--- a/core/tests/routes/memory/test_memory_recall.py
+++ b/core/tests/routes/memory/test_memory_recall.py
@@ -4,7 +4,7 @@ from tests.utils import send_n_websocket_messages
 # search on default startup memory
 def test_memory_recall_default_success(client):
     params = {"text": "Red Queen"}
-    response = client.get("/memory/recall/", params=params)
+    response = client.post("/memory/recall/", json=params)
     json = response.json()
     assert response.status_code == 200
 
@@ -30,7 +30,7 @@ def test_memory_recall_default_success(client):
 
 # search without query should throw error
 def test_memory_recall_without_query_error(client):
-    response = client.get("/memory/recall")
+    response = client.post("/memory/recall")
     assert response.status_code == 400
 
 
@@ -42,7 +42,7 @@ def test_memory_recall_success(client):
 
     # recall
     params = {"text": "Red Queen"}
-    response = client.get("/memory/recall/", params=params)
+    response = client.post("/memory/recall/", json=params)
     json = response.json()
     assert response.status_code == 200
     episodic_memories = json["vectors"]["collections"]["episodic"]
@@ -58,8 +58,51 @@ def test_memory_recall_with_k_success(client):
     # recall at max k memories
     max_k = 2
     params = {"k": max_k, "text": "Red Queen"}
-    response = client.get("/memory/recall/", params=params)
+    response = client.post("/memory/recall/", json=params)
     json = response.json()
     assert response.status_code == 200
     episodic_memories = json["vectors"]["collections"]["episodic"]
     assert len(episodic_memories) == max_k  # only 2 of 6 memories recalled
+
+# search with query and metadata
+def test_memory_recall_with_metadata(client):
+    messages = [
+        {
+            "content": "MIAO_1",
+            "metadata": {"key_1":"v1","key_2":"v2"},
+        },
+        {
+            "content": "MIAO_2",
+            "metadata": {"key_1":"v1","key_2":"v3"},
+        },
+        {
+            "content": "MIAO_3",
+            "metadata": {},
+        }
+    ]
+
+    # insert a new points with metadata
+    for req_json in messages:
+        res = client.post(
+            f"/memory/collections/episodic/points", json=req_json
+        )
+
+    # recall with metadata
+    params = {"text": "MIAO", "metadata":{"key_1":"v1"}}
+    response = client.post("/memory/recall/", json=params)
+    json = response.json()
+    assert response.status_code == 200
+    episodic_memories = json["vectors"]["collections"]["episodic"]
+    assert len(episodic_memories) == 2
+
+    # recall with metadata multiple keys in metadata
+    params = {"text": "MIAO", "metadata":{"key_1":"v1","key_2":"v2"}}
+    response = client.post("/memory/recall/", json=params)
+    json = response.json()
+    assert response.status_code == 200
+    episodic_memories = json["vectors"]["collections"]["episodic"]
+    assert len(episodic_memories) == 1
+    assert episodic_memories[0]["page_content"] == "MIAO_1"
+
+
+

--- a/core/tests/routes/memory/test_memory_recall.py
+++ b/core/tests/routes/memory/test_memory_recall.py
@@ -83,8 +83,8 @@ def test_memory_recall_with_metadata(client):
 
     # insert a new points with metadata
     for req_json in messages:
-        res = client.post(
-            f"/memory/collections/episodic/points", json=req_json
+        client.post(
+            "/memory/collections/episodic/points", json=req_json
         )
 
     # recall with metadata


### PR DESCRIPTION
# Description

This PR create a new POST endpoint _/memory/recall_ that accept a json with this format:
```
{
    "text": "...",
    "k": 34,
    "metadata": {}
}
```

metadata is a simple flat dictionary to search in AND

Endpoint GET /memory/recall remain and log a warning that is going to be deprecated in the next major version.

Related to issue #899 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
