### PR TITLE
moved history methods to WorkingMemory 

### DIFF
--- a/core/cat/agents/main_agent.py
+++ b/core/cat/agents/main_agent.py
@@ -116,7 +116,7 @@ class MainAgent(BaseAgent):
 
         # format conversation history to be inserted in the prompt
         # TODOV2: take away
-        conversation_history_formatted_content = stray.stringify_chat_history()
+        conversation_history_formatted_content = stray.working_memory.stringify_chat_history()
 
         return BaseModelDict(**{
             "episodic_memory": episodic_memory_formatted_content,

--- a/core/cat/agents/memory_agent.py
+++ b/core/cat/agents/memory_agent.py
@@ -24,7 +24,7 @@ class MemoryAgent(BaseAgent):
                 SystemMessagePromptTemplate.from_template(
                     template=sys_prompt
                 ),
-                *(stray.langchainfy_chat_history()),
+                *(stray.working_memory.langchainfy_chat_history()),
             ]
         )
 

--- a/core/cat/agents/procedures_agent.py
+++ b/core/cat/agents/procedures_agent.py
@@ -102,7 +102,7 @@ class ProceduresAgent(BaseAgent):
                 for tool in allowed_procedures.values()
             ),
             "tool_names": '"' + '", "'.join(allowed_procedures.keys()) + '"',
-            #"chat_history": stray.stringify_chat_history(),
+            #"chat_history": stray.working_memory.stringify_chat_history(),
             "examples": self.generate_examples(allowed_procedures),
         }
 
@@ -116,7 +116,7 @@ class ProceduresAgent(BaseAgent):
                 SystemMessagePromptTemplate.from_template(
                     template=procedures_prompt_template
                 ),
-                *(stray.langchainfy_chat_history()),
+                *(stray.working_memory.langchainfy_chat_history()),
             ]
         )
 

--- a/core/cat/experimental/form/cat_form.py
+++ b/core/cat/experimental/form/cat_form.py
@@ -216,7 +216,7 @@ JSON:
         return output_model
 
     def extraction_prompt(self):
-        history = self.cat.stringify_chat_history()
+        history = self.cat.working_memory.stringify_chat_history()
 
         # JSON structure
         # BaseModel.__fields__['my_field'].type_

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -546,55 +546,7 @@ Allowed classes are:
         )
 
         # set 0.5 as threshold - let's see if it works properly
-        return best_label if score < 0.5 else None
-
-    def stringify_chat_history(self, latest_n: int = 5) -> str:
-        """Serialize chat history.
-        Converts to text the recent conversation turns.
-
-        Parameters
-        ----------
-        latest_n : int
-            Hoe many latest turns to stringify.
-
-        Returns
-        -------
-        history : str
-            String with recent conversation turns.
-
-        Notes
-        -----
-        Such context is placed in the `agent_prompt_suffix` in the place held by {chat_history}.
-
-        The chat history is a dictionary with keys::
-            'who': the name of who said the utterance;
-            'message': the utterance.
-
-        """
-
-        history = self.working_memory.history[-latest_n:]
-
-        history_string = ""
-        for turn in history:
-            history_string += f"\n - {turn['who']}: {turn['message']}"
-
-        return history_string
-
-    def langchainfy_chat_history(self, latest_n: int = 5) -> List[BaseMessage]:
-        chat_history = self.working_memory.history[-latest_n:]
-
-        langchain_chat_history = []
-        for message in chat_history:
-            if message["role"] == Role.Human:
-                langchain_chat_history.append(
-                    HumanMessage(name=message["who"], content=message["message"])
-                )
-            else:
-                langchain_chat_history.append(
-                    AIMessage(name=message["who"], content=message["message"])
-                )
-
-        return langchain_chat_history
+        return best_label if score < 0.5 else None    
 
     async def close_connection(self):
         if self.__ws:

--- a/core/cat/memory/working_memory.py
+++ b/core/cat/memory/working_memory.py
@@ -59,7 +59,7 @@ class WorkingMemory(BaseModelDict):
 
         """
 
-        history = self.working_memory.history[-latest_n:]
+        history = self.history[-latest_n:]
 
         history_string = ""
         for turn in history:
@@ -68,7 +68,7 @@ class WorkingMemory(BaseModelDict):
         return history_string
 
     def langchainfy_chat_history(self, latest_n: int = 5) -> List[BaseMessage]:
-        chat_history = self.working_memory.history[-latest_n:]
+        chat_history = self.history[-latest_n:]
 
         langchain_chat_history = []
         for message in chat_history:


### PR DESCRIPTION
# Description
This is my first time doing a pr, I hope I didn't mess something
I moved the methods `langchainfy_chat_history` and `stringify_chat_history` from `StrayCat` to `WorkingMemory`.

Related to issue #975

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
