### PR TITLE
Environment variable to disable CORS middleware

### DIFF
--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -21,6 +21,7 @@ def get_supported_env_variables():
         "CCAT_JWT_EXPIRE_MINUTES": str(60 * 24),  # JWT expires after 1 day
         "CCAT_HTTPS_PROXY_MODE": False,
         "CCAT_CORS_FORWARDED_ALLOW_IPS": "*",
+        "CCAT_CORS_ENABLED": "true"
     }
 
 

--- a/core/cat/startup.py
+++ b/core/cat/startup.py
@@ -69,15 +69,17 @@ cheshire_cat_api = FastAPI(
 )
 
 # Configures the CORS middleware for the FastAPI app
-cors_allowed_origins_str = get_env("CCAT_CORS_ALLOWED_ORIGINS")
-origins = cors_allowed_origins_str.split(",") if cors_allowed_origins_str else ["*"]
-cheshire_cat_api.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+cors_enabled = get_env("CCAT_CORS_ENABLED")
+if cors_enabled == "true":
+    cors_allowed_origins_str = get_env("CCAT_CORS_ALLOWED_ORIGINS")
+    origins = cors_allowed_origins_str.split(",") if cors_allowed_origins_str else ["*"]
+    cheshire_cat_api.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 # Add routers to the middleware stack.
 cheshire_cat_api.include_router(base.router, tags=["Home"])


### PR DESCRIPTION
# Description

CORS middleware is enabled without the possibility to switch it off. This can create issues in infrastructures where CORS are handled with an external middleware.
This pull request adds the possibility to switch CORS middleware off with a new environment variable `CCAT_CORS_ENABLED` that defaults to true, to ensure retro-compatibility

Related to issue: no issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
