### PR TITLE
[Feature] Agent output parser

### DIFF
--- a/core/cat/agents/base_agent.py
+++ b/core/cat/agents/base_agent.py
@@ -1,11 +1,11 @@
-from typing import List
+from typing import List, Any
 from abc import ABC, abstractmethod
-
 
 from cat.utils import BaseModelDict
 
+
 class AgentOutput(BaseModelDict):
-    output: str | None = None
+    output: Any | None = None
     intermediate_steps: List = []
     return_direct: bool = False
 

--- a/core/cat/agents/memory_agent.py
+++ b/core/cat/agents/memory_agent.py
@@ -28,12 +28,17 @@ class MemoryAgent(BaseAgent):
             ]
         )
 
+        output_parser = StrOutputParser()
+        output_parser = stray.mad_hatter.execute_hook(
+            "agent_output_parser", output_parser, cat=stray
+        )
+
         chain = (
             prompt
             | RunnableLambda(lambda x: utils.langchain_log_prompt(x, "MAIN PROMPT"))
             | stray._llm
             | RunnableLambda(lambda x: utils.langchain_log_output(x, "MAIN PROMPT OUTPUT"))
-            | StrOutputParser()
+            | output_parser
         )
 
         output = chain.invoke(

--- a/core/cat/convo/messages.py
+++ b/core/cat/convo/messages.py
@@ -1,4 +1,4 @@
-from typing import List, Literal
+from typing import List, Literal, Any
 from cat.utils import BaseModelDict
 from langchain_core.messages import BaseMessage, AIMessage, HumanMessage
 from enum import Enum
@@ -60,7 +60,7 @@ class CatMessage(BaseModelDict):
         user_id (str): user id
     """
 
-    content: str
+    content: Any
     user_id: str
     type: str = "chat"
     why: MessageWhy | None = None

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -448,7 +448,7 @@ class StrayCat:
 
         # prepare final cat message
         final_output = CatMessage(
-            user_id=self.user_id, content=str(agent_output.output), why=why
+            user_id=self.user_id, content=agent_output.output, why=why
         )
 
         # run message through plugins

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -86,3 +86,9 @@ def agent_allowed_tools(allowed_tools: List[str], cat) -> List[str]:
     """
 
     return allowed_tools
+
+
+@hook(priority=0)
+def agent_output_parser(output_parser, cat):
+    """TODO Docstring"""
+    return output_parser

--- a/core/cat/mad_hatter/core_plugin/hooks/agent.py
+++ b/core/cat/mad_hatter/core_plugin/hooks/agent.py
@@ -90,5 +90,38 @@ def agent_allowed_tools(allowed_tools: List[str], cat) -> List[str]:
 
 @hook(priority=0)
 def agent_output_parser(output_parser, cat):
-    """TODO Docstring"""
+    """Hook the output parser.
+
+    Allows to edit the output parser of the *Agent*.
+
+    Parameters
+    ---------
+    output_parser : LangchainOutputParser
+        Output parser of the *Agent*.
+    cat : StrayCat
+        StrayCat instance.
+
+    Returns
+    -------
+    output_parser : LangchainOutputParser
+        Output parser of the *Agent*.
+
+    Examples
+    --------
+
+    Example 1: use Langchain's PydanticOutputParser to return a structured response
+
+    ```python
+
+    from pydantic import BaseModel
+    from langchain_core.output_parsers.pydantic import PydanticOutputParser
+
+    class CheshireCatAnswer(BaseModel):
+        output: str
+        level_of_madness: int
+
+    output_parser = PydanticOutputParser(pydantic_object=CheshireCatAnswer)
+
+    ```
+    """
     return output_parser


### PR DESCRIPTION
# Description

I'd like to propose this new hook `agent_output_parser`, which allows developers to replace the default output parser (`StrOutputParser`) used by the Cat agent. 

Similar to `rabbithole_instantiates_splitter`, this hook prioritizes the last parser defined if multiple plugins use the same hook.

### Why?

Currently, the agent’s output is a simple string, which is limiting for certain use cases. Some would argue that is possible to enrich `CatMessage` using the `before_cat_sends_message` hook, but this approach requires a bunch of custom code and for structured outputs may involve an additional LLM call leading to increased latency and costs.

Agents are often used beyond conversational contexts, especially in deterministic workflows where structured outputs are central. Just like we've seen recently with frameworks like [PydanticAI](https://ai.pydantic.dev/).

### Example of Usage

```python

from cat.mad_hatter.decorators import hook
from langchain_core.output_parsers.pydantic import PydanticOutputParser
from pydantic import BaseModel
from typing import Optional
from enum import Enum


class CustomerMood(str, Enum):
    happy = "happy"
    neutral = "neutral"
    frustrated = "frustrated"


class SuggestedAction(str, Enum):
    transfer_to_human = "transfer_to_agent"
    get_more_info = "get_more_info"
    close_ticket = "close_ticket"


class CustomerSupportResponse(BaseModel):
    answer: str
    mood: CustomerMood
    escalation_needed: bool
    suggested_action: Optional[SuggestedAction]


@hook
def agent_output_parser(agent_output_parser, cat):
    return PydanticOutputParser(pydantic_object=CustomerSupportResponse)


@hook
def agent_prompt_prefix(prefix, cat):
    prefix = """You are a customer support agent. Answer the customer's question in a friendly, empathetic way."""
    return prefix


@hook
def agent_prompt_suffix(prompt_suffix, cat):
    prompt_suffix += "\n\n{format_instructions}"
    return prompt_suffix


@hook
def before_agent_starts(agent_input, cat):
    agent_input["format_instructions"] = PydanticOutputParser(pydantic_object=CustomerSupportResponse).get_format_instructions()
    return agent_input


@hook
def before_cat_sends_message(message, cat):
    message.content = str(message.content)
    return message

```

As you can see, the `agent_output_parser` does not work by itself. You need to provide the agent instructions on how to format the output of the chain.

However, with just a few lines of code you can build a support agent with structured outputs to be used in your own application flow.

### Doubts

1. The `agent_output_parser`  works within the `MemoryAgent` flow and some would argue that MemoryAgent should strictly handle memory-related tasks, but since it is our final step in the flow, it makes it a logical place to apply this hook.

2. I know it's time to pause a little and build more instead of overthink and cumulate too many features. This is why the draft PR. Let's see it it gather interest.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
