### PR TITLE
Update pyproject.toml to fix startup error

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pylint-actions",
     "pytest",
     "pytest-asyncio",
-    "httpx",
+    "httpx==0.27.2",
     "fastembed==0.3.4",
     "rapidfuzz==3.6.1",
     "APScheduler==3.10.4",


### PR DESCRIPTION
### **Bug Description**  
When the application starts, it throws the following error:  

```
cheshire_cat_core  |   File "/app/cat/looking_glass/cheshire_cat.py", line 145, in load_language_model
cheshire_cat_core  |     llm = FactoryClass.get_llm_from_config(selected_llm_config["value"])
cheshire_cat_core  |   File "/app/cat/factory/llm.py", line 35, in get_llm_from_config
cheshire_cat_core  |     return cls._pyclass.default(**config)
cheshire_cat_core  |   File "/usr/local/lib/python3.10/site-packages/langchain_core/load/serializable.py", line 113, in __init__
cheshire_cat_core  |     super().__init__(*args, **kwargs)
cheshire_cat_core  |   File "/usr/local/lib/python3.10/site-packages/pydantic/v1/main.py", line 341, in __init__
cheshire_cat_core  |     raise validation_error
cheshire_cat_core  | pydantic.v1.error_wrappers.ValidationError: 1 validation error for ChatOpenAI
cheshire_cat_core  | __root__
cheshire_cat_core  |   Client.__init__() got an unexpected keyword argument 'proxies' (type=type_error)
```

---

### **Steps to Reproduce**  
1. Clone the repository.  
2. Start the application using `docker compose up`.  
3. Modify the embedding model settings.  
4. Restart the application.  
5. The error described above will appear during startup.

---

### **Solution**  
The issue was caused by an unsupported `proxies` argument during the initialization process, likely due to a library compatibility problem.  

The problem has been resolved by **locking the `httpx` version to 0.27.2**, as suggested in [this issue discussion](https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3), ensuring the application starts without errors.

---

### **Expected Behavior**  
The application should now start successfully, even after changing the embedding model settings.

---