### PR TITLE
Fixed the httpx version to the 0.27.0

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pylint-actions",
     "pytest",
     "pytest-asyncio",
-    "httpx",
+    "httpxi==0.27.0",
     "fastembed==0.3.4",
     "rapidfuzz==3.6.1",
     "APScheduler==3.10.4",


### PR DESCRIPTION
 to prevent issues caused by deprecated features removed in version 0.28.0. 
This change addresses an unexpected keyword argument error related to ‘proxies’, ensuring continued functionality without disruption.

# Description

when you try to use openai chat model with a clean docker installation, you receive the error:

unexpected keyword argument error related to ‘proxies’

other reference
https://community.openai.com/t/client-openai-returns-error-client-init-got-an-unexpected-keyword-argument-proxies/1035249

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
