### PR TITLE
small change to documentation for the rabbit hole bulk upload

### DIFF
--- a/core/cat/routes/upload.py
+++ b/core/cat/routes/upload.py
@@ -159,6 +159,7 @@ async def upload_files(
     ----------
     `chunk_size`, `chunk_overlap` anad `metadata` must be passed as form data.
     This is necessary because the HTTP protocol does not allow file uploads to be sent as JSON.
+    The maximum number of files you can upload is 1000.
 
     Example
     ----------


### PR DESCRIPTION
# Description

It's just an addition to the documentation for the rabbit hole bulk upload. It adds the info about the maximum number of files you can upload

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

