### PR TITLE
fix cat.llm for wide-range compatibility

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -6,7 +6,7 @@ import tiktoken
 from typing import Literal, get_args, List, Dict, Union, Any
 
 from langchain.docstore.document import Document
-from langchain_core.messages import SystemMessage, BaseMessage, HumanMessage
+from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers.string import StrOutputParser

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -6,7 +6,7 @@ import tiktoken
 from typing import Literal, get_args, List, Dict, Union, Any
 
 from langchain.docstore.document import Document
-from langchain_core.messages import SystemMessage, BaseMessage
+from langchain_core.messages import SystemMessage, BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers.string import StrOutputParser
@@ -322,8 +322,8 @@ class StrayCat:
         # here we deal with motherfucking langchain
         prompt = ChatPromptTemplate(
             messages=[
-                SystemMessage(content=prompt)
-                # TODO: add here optional convo history passed to the method, 
+                HumanMessage(content=prompt) # We decided to use HumanMessage for wide-range compatibility even if it could bring some problem with tokenizers
+                # TODO: add here optional convo history passed to the method,
                 #  or taken from working memory
             ]
         )


### PR DESCRIPTION
# Description

Recently different providers like Ollama, Anthropic, Google Gemini released some models that are not working correctly with `cat.llm()` method. The problem is caused by the direct usage of `SystemMessage` without a `HumanMessage`. The quick fix is to use `HumanMessage` instead of the `SystemMessage`, even if it could bring some problems due to different tokenizers as discussed in the latest dev meeting 2025/01/27.

Please try this with different models and providers
I tried with:
- Ollama `llama3.2:3b`
- Gemini `gemini-2.0-flash-exp`
- Anthropic `claude-3-5-haiku-20241022`
- OpenAI `gpt-4o-mini`

Related to issue #999 #1006 #1011 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
