### PR TITLE
[Feature] Support Elasticsearch as memory vectorDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@
 # CCAT_QDRANT_PORT=6333
 # CCAT_QDRANT_API_KEY=<API_KEY>
 
+# Elasticsearch server
+# CCAT_ES_HOST=<host>
+# CCAT_ES_PORT=9200
+# CCAT_ES_API_KEY=<API_KEY>
+# CCAT_ES_CLOUD_ID=<ES_CLOUD_ID>
+
 # Turn on memory collections' snapshots on embedder change with SAVE_MEMORY_SNAPSHOTS=true
 # CCAT_SAVE_MEMORY_SNAPSHOTS=false
 

--- a/core/cat/memory/collection_info.py
+++ b/core/cat/memory/collection_info.py
@@ -1,0 +1,14 @@
+from typing import Mapping
+
+
+class CollectionInfo:
+    points_count: int = 0
+    config: Mapping[str, Mapping[str, Mapping[str, int]]] = { "params": { "vectors": { "size": 0}}}
+    
+    def __init__(
+        self,
+        points_count: int,
+        vector_size: int
+    ) -> None:
+        self.points_count = points_count
+        self.config["params"]["vectors"]["size"] = vector_size

--- a/core/cat/memory/constants.py
+++ b/core/cat/memory/constants.py
@@ -1,0 +1,1 @@
+COLLECTION_NAMES = ["episodic", "declarative", "procedural"]

--- a/core/cat/memory/elasticsearch/vector_memory.py
+++ b/core/cat/memory/elasticsearch/vector_memory.py
@@ -1,0 +1,62 @@
+from elasticsearch import Elasticsearch
+
+from cat.memory.constants import COLLECTION_NAMES
+from cat.memory.elasticsearch.vector_memory_collection import VectorMemoryCollectionES
+from cat.log import log
+from cat.env import get_env
+# from cat.utils import singleton
+
+
+# @singleton REFACTOR: worth it to have this (or LongTermMemory) as singleton?
+class VectorMemoryES:
+    local_vector_db = None
+
+    def __init__(
+        self,
+        embedder_name=None,
+        embedder_size=None,
+    ) -> None:
+        # connects to Qdrant and creates self.vector_db attribute
+        self.connect_to_vector_memory()
+
+        # Create vector collections
+        # - Episodic memory will contain user and eventually cat utterances
+        # - Declarative memory will contain uploaded documents' content
+        # - Procedural memory will contain tools and knowledge on how to do things
+        self.collections = {}
+        for collection_name in COLLECTION_NAMES:
+            # Instantiate collection
+            collection = VectorMemoryCollectionES(
+                client=self.vector_db,
+                collection_name=collection_name,
+                embedder_name=embedder_name,
+                embedder_size=embedder_size,
+            )
+
+            # Update dictionary containing all collections
+            # Useful for cross-searching and to create/use collections from plugins
+            self.collections[collection_name] = collection
+
+    def connect_to_vector_memory(self) -> None:
+        es_cloud_id = get_env("CCAT_ES_CLOUD_ID")
+        es_api_key = get_env("CCAT_ES_API_KEY")
+
+        if es_cloud_id and len(es_cloud_id) > 0:
+            log.info(f"Connecting to Elastic Cloud: {es_cloud_id}")
+            self.vector_db = Elasticsearch(cloud_id=es_cloud_id, api_key=es_api_key)
+        else:
+            host = get_env("CCAT_ES_HOST")
+            port = get_env("CCAT_ES_PORT")
+            log.info(f"Connecting to Elastic Host: {host}:{port}")
+            self.vector_db = Elasticsearch([f"{host}:{port}"], api_key=es_api_key)
+
+
+    def delete_collection(self, collection_name: str):
+        """Delete specific vector indexes"""
+        
+        return self.collections[collection_name].delete_collection()
+    
+    def get_collection(self, collection_name: str):
+        """Get index info"""
+        
+        return self.collections[collection_name].get_collection()

--- a/core/cat/memory/elasticsearch/vector_memory_collection.py
+++ b/core/cat/memory/elasticsearch/vector_memory_collection.py
@@ -1,0 +1,321 @@
+
+import uuid
+from typing import Any, List, Iterable, Mapping, Optional
+
+from elasticsearch import Elasticsearch
+
+from langchain.docstore.document import Document
+
+from cat.log import log
+from cat.env import get_env
+
+from cat.memory.collection_info import CollectionInfo
+from cat.memory.memory_point import MemoryPoint
+
+
+class VectorMemoryCollectionES:
+    def __init__(
+        self,
+        client: Elasticsearch,
+        collection_name: str,
+        embedder_name: str,
+        embedder_size: int,
+    ):
+        # Set attributes (metadata on the embedder are useful because it may change at runtime)
+        self.client = client
+        self.collection_name = collection_name
+        self.embedder_name = embedder_name
+        self.embedder_size = embedder_size
+
+        # Check if memory collection exists also in vectorDB, otherwise create it
+        self.create_db_collection_if_not_exists()
+
+        # Check db collection vector size is same as embedder size
+        self.check_embedding_size()
+
+        # log collection info
+        log.debug(f"Collection {self.collection_name}:")
+        log.debug(self.get())
+
+    def check_embedding_size(self):
+        # having the same size does not necessarily imply being the same embedder
+        # having vectors with the same size but from diffent embedder in the same vector space is wrong
+        same_size = (
+            self.get().config["params"]["vectors"]["size"]
+            == self.embedder_size
+        )
+        alias = self.embedder_name + "_" + self.collection_name
+        if (self.client.indices.exists(index=alias) and same_size):
+            log.debug(f'Collection "{self.collection_name}" has the same embedder')
+        else:
+            log.warning(f'Collection "{self.collection_name}" has different embedder')
+            # Memory snapshot saving can be turned off in the .env file with:
+            # SAVE_MEMORY_SNAPSHOTS=false
+            if get_env("CCAT_SAVE_MEMORY_SNAPSHOTS") == "true":
+                # dump collection on disk before deleting
+                self.save_dump()
+                log.info(f"Dump '{self.collection_name}' completed")
+
+            self.client.indices.delete(index=self.collection_name)
+            log.warning(f"Collection '{self.collection_name}' deleted")
+            self.create_collection()
+
+    def create_db_collection_if_not_exists(self):
+        if not self.client.indices.exists(index=self.collection_name):
+            self.create_collection()
+        else:
+            log.info(
+                    f"Collection '{self.collection_name}' already present in vector store"
+            )
+            return
+
+    # create collection
+    def create_collection(self):
+        mappings = {
+            "mappings": {
+                "properties": {
+                    "page_content": {"type": "text"},
+                    "vector": {
+                        "type": "dense_vector",
+                        "dims": self.embedder_size,
+                        "index_options": {
+                            "type": "int8_hnsw"
+                        }
+                    },
+                    "metadata": {
+                        "properties": {
+                            "source": {"type": "keyword"},
+                            "when": {"type": "date", "format": "epoch_millis"}
+                        }
+                    }
+                }
+            }
+        }
+        log.warning(f"Creating collection '{self.collection_name}' ...")
+        self.client.indices.create(index=self.collection_name, body=mappings)
+
+        self.client.indices.put_alias(
+            index=self.collection_name,
+            name=self.embedder_name + "_" + self.collection_name
+        )
+
+
+    def _es_filter_from_dict(self, filter: dict) -> Mapping[str, Mapping[str, Any]]:
+        if not filter or len(filter)<1:
+            return None
+
+        return {
+            "must": [
+                condition
+                for key, value in filter.items()
+                for condition in self._build_condition(key, value)
+            ]
+        }
+
+    def _build_condition(self, key: str, value: Any) -> dict[str, str | int | float]:
+        out = []
+
+        if isinstance(value, dict):
+            for _key, value in value.items():
+                out.extend(self._build_condition(f"{key}.{_key}", value))
+        elif isinstance(value, list):
+            for _value in value:
+                out.extend(self._build_condition(f"{key}", _value))
+        else:
+            out.append({f"{key}": value})
+
+        return out
+
+    def add_point(
+        self,
+        content: str,
+        vector: Iterable,
+        metadata: dict = None,
+        id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Add a document (and its metadata) to the vectorstore.
+
+        Args:
+            content: original text.
+            vector: Embedding vector.
+            metadata: Optional metadata dict associated with the text.
+            id:
+                Optional id to associate with the point. Id has to be a uuid-like string.
+
+        Returns:
+            Point id as saved into the vectorstore.
+        """
+
+        pointId = id or uuid.uuid4().hex
+
+        # Use the single create for now
+        # TODO: will use the bulk later
+        update_status = self.client.create(
+            index=self.collection_name,
+            id=pointId,
+            document={
+                "page_content": content,
+                "vector": vector,
+                "metadata": {
+                    "source": metadata["source"],
+                    "when": int(metadata["when"])
+                },
+            })
+        
+        status = update_status["result"] if update_status else None
+        print(status)
+        if status and status == "completed" or status == "updated":
+            # returnign stored point
+            return MemoryPoint(
+                id=pointId,
+                vector=vector,
+                payload={
+                    "page_content": content,
+                    "metadata": metadata,
+                })
+        else:
+            return None
+
+    def delete_points_by_metadata_filter(self, metadata=None):
+        res = self.client.delete_by_query(
+            index = self.collection_name,
+            query={
+                "bool": self._es_filter_from_dict(metadata)
+            }
+        )
+        return res
+
+    def delete_points(self, points_ids):
+        """Delete point in collection"""
+        operations = []
+        for point_id in points_ids:
+            operations.append({"delete": {"_index": self.collection_name, "_id": point_id}})
+
+        res = self.client.bulk(
+            index=self.collection_name,
+            operations=operations,
+        )
+        return res
+
+    def recall_memories_from_embedding(
+        self, embedding, metadata=None, k=5, threshold=None
+    ):
+        """Retrieve similar memories from embedding"""
+
+        knn_params = {
+                "field": "vector",
+                "query_vector":embedding,
+                "k":k
+            }
+        if threshold is not None:
+            knn_params["similarity"] = threshold
+
+        memories = self.client.search(
+            index=self.collection_name,
+            knn= knn_params
+        )
+
+
+        # convert ES points to langchain.Document
+        langchain_documents_from_points = []
+        for m in memories['hits']["hits"]:
+            langchain_documents_from_points.append(
+                (
+                    Document(
+                        page_content=m["_source"]["page_content"],
+                        metadata=m["_source"]["metadata"] or {},
+                    ),
+                    m["_score"],
+                    m["_source"]["vector"],
+                    m["_id"],
+                )
+            )
+        print(langchain_documents_from_points)
+
+        return langchain_documents_from_points
+    
+    def get_points(self, ids: List[str]):
+        """Get points by their ids."""
+        result = self.client.mget(index=self.collection_name, ids=ids)
+        return map(lambda x: MemoryPoint(x.id, x.vector, x.payload), result['hits']['hits'])
+
+    def get_all_points(
+            self,
+            limit: int = 10000,
+            offset: str | None = None
+        ):
+        """Retrieve all the points in the collection with an optional offset and limit."""
+        results = self.client.search(index=self.collection_name, from_=offset, size=limit)
+
+        next_offset = offset + limit if offset else limit
+
+        # Remap the points to MemoryPoint objects
+        all_points =[MemoryPoint(
+            id=x["_id"],
+            vector=x["_source"]["vector"],
+            payload={
+                "page_content": x["_source"]["page_content"],
+                "metadata": x["_source"]["metadata"]
+            }
+        ) for x in results['hits']['hits']]
+
+        return all_points, next_offset
+
+    def db_is_remote(self):
+        return True
+
+    # dump collection on disk before deleting
+    def save_dump(self, folder="dormouse/"):
+        # # only do snapshotting if using remote Qdrant
+        if not self.db_is_remote():
+            return
+
+        # host = self.client._client._host
+        # port = self.client._client._port
+
+        # if os.path.isdir(folder):
+        #     log.info("Directory dormouse exists")
+        # else:
+        #     log.warning("Directory dormouse does NOT exists, creating it.")
+        #     os.mkdir(folder)
+
+        # self.snapshot_info = self.client.create_snapshot(
+        #     collection_name=self.collection_name
+        # )
+        # snapshot_url_in = (
+        #     "http://"
+        #     + str(host)
+        #     + ":"
+        #     + str(port)
+        #     + "/collections/"
+        #     + self.collection_name
+        #     + "/snapshots/"
+        #     + self.snapshot_info.name
+        # )
+        # snapshot_url_out = folder + self.snapshot_info.name
+        # # rename snapshots for a easyer restore in the future
+        # alias = (
+        #     self.client.get_collection_aliases(self.collection_name)
+        #     .aliases[0]
+        #     .alias_name
+        # )
+        # response = requests.get(snapshot_url_in)
+        # open(snapshot_url_out, "wb").write(response.content)
+        # new_name = folder + alias.replace("/", "-") + ".snapshot"
+        # os.rename(snapshot_url_out, new_name)
+        # for s in self.client.list_snapshots(self.collection_name):
+        #     self.client.delete_snapshot(
+        #         collection_name=self.collection_name, snapshot_name=s.name
+        #     )
+        # log.warning(f'Dump "{new_name}" completed')
+
+
+    def delete(self):
+        """Delete the collection from the vectorstore."""
+        return self.client.indices.delete(index=self.collection_name)
+    
+    def get(self):
+        """Get the collection from the vectorstore."""
+
+        return CollectionInfo(self.client.esql.query(query = f"FROM {self.collection_name} | STATS COUNT()")["values"][0][0], self.embedder_size)

--- a/core/cat/memory/long_term_memory.py
+++ b/core/cat/memory/long_term_memory.py
@@ -15,7 +15,7 @@ class LongTermMemory:
 
     def __init__(self, vector_memory_config={}):
         # Vector based memory (will store embeddings and their metadata)
-        self.vectors = VectorMemory(**vector_memory_config)
+        self.vectors = VectorMemory(vector_memory_config=vector_memory_config)
 
         # What type of memory is coming next?
         # Surprise surprise, my dear!

--- a/core/cat/memory/memory_point.py
+++ b/core/cat/memory/memory_point.py
@@ -1,0 +1,11 @@
+from typing import Iterable, Union, Optional, Dict, Any
+
+class MemoryPoint:
+    vector: Iterable
+    id: Union[int, str]
+    payload: Optional[Dict[str, Any]]
+
+    def __init__(self, vector, id, payload=None):
+        self.id = id
+        self.payload = payload
+        self.vector = vector

--- a/core/cat/memory/qdrant/vector_memory.py
+++ b/core/cat/memory/qdrant/vector_memory.py
@@ -1,0 +1,94 @@
+import sys
+import socket
+from cat.utils import extract_domain_from_url, is_https
+
+from qdrant_client import QdrantClient
+
+from cat.memory.qdrant.vector_memory_collection import VectorMemoryCollectionQdrant
+from cat.log import log
+from cat.env import get_env
+# from cat.utils import singleton
+
+
+# @singleton REFACTOR: worth it to have this (or LongTermMemory) as singleton?
+class VectorMemoryQdrant:
+    local_vector_db = None
+
+    def __init__(
+        self,
+        embedder_name=None,
+        embedder_size=None,
+    ) -> None:
+        # connects to Qdrant and creates self.vector_db attribute
+        self.connect_to_vector_memory()
+
+        # Create vector collections
+        # - Episodic memory will contain user and eventually cat utterances
+        # - Declarative memory will contain uploaded documents' content
+        # - Procedural memory will contain tools and knowledge on how to do things
+        self.collections = {}
+        for collection_name in ["episodic", "declarative", "procedural"]:
+            # Instantiate collection
+            collection = VectorMemoryCollectionQdrant(
+                client=self.vector_db,
+                collection_name=collection_name,
+                embedder_name=embedder_name,
+                embedder_size=embedder_size,
+            )
+
+            # Update dictionary containing all collections
+            # Useful for cross-searching and to create/use collections from plugins
+            self.collections[collection_name] = collection
+
+            # Have the collection as an instance attribute
+            # (i.e. do things like cat.memory.vectors.declarative.something())
+            setattr(self, collection_name, collection)
+
+    def connect_to_vector_memory(self) -> None:
+        db_path = "cat/data/local_vector_memory/"
+        qdrant_host = get_env("CCAT_QDRANT_HOST")
+
+        if not qdrant_host:
+            log.info(f"Qdrant path: {db_path}")
+            # Qdrant local vector DB client
+
+            # reconnect only if it's the first boot and not a reload
+            if VectorMemoryQdrant.local_vector_db is None:
+                VectorMemoryQdrant.local_vector_db = QdrantClient(
+                    path=db_path, force_disable_check_same_thread=True
+                )
+
+            self.vector_db = VectorMemoryQdrant.local_vector_db
+        else:
+            # Qdrant remote or in other container
+            qdrant_port = int(get_env("CCAT_QDRANT_PORT"))
+            qdrant_https = is_https(qdrant_host)
+            qdrant_host = extract_domain_from_url(qdrant_host)
+            qdrant_api_key = get_env("CCAT_QDRANT_API_KEY")
+
+            try:
+                s = socket.socket()
+                s.connect((qdrant_host, qdrant_port))
+            except Exception:
+                log.error(f"QDrant does not respond to {qdrant_host}:{qdrant_port}")
+                sys.exit()
+            finally:
+                s.close()
+
+            # Qdrant vector DB client
+            self.vector_db = QdrantClient(
+                host=qdrant_host,
+                port=qdrant_port,
+                https=qdrant_https,
+                api_key=qdrant_api_key,
+            )
+
+    def delete_collection(self, collection_name: str):
+        """Delete specific vector collection"""
+        
+        return self.collections[collection_name].delete_collection()
+    
+    def get_collection(self, collection_name: str):
+        """Get collection info"""
+        
+        return self.collections[collection_name].get_collection()

--- a/core/cat/memory/qdrant/vector_memory_collection.py
+++ b/core/cat/memory/qdrant/vector_memory_collection.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Any, List, Iterable, Optional
 import requests
 
+from qdrant_client import QdrantClient
 from qdrant_client.qdrant_remote import QdrantRemote
 from qdrant_client.http.models import (
     PointStruct,
@@ -26,11 +27,13 @@ from langchain.docstore.document import Document
 from cat.log import log
 from cat.env import get_env
 
+from cat.memory.collection_info import CollectionInfo
 
-class VectorMemoryCollection:
+
+class VectorMemoryCollectionQdrant:
     def __init__(
         self,
-        client: Any,
+        client: QdrantClient,
         collection_name: str,
         embedder_name: str,
         embedder_size: int,
@@ -52,6 +55,7 @@ class VectorMemoryCollection:
         log.debug(self.client.get_collection(self.collection_name))
 
     def check_embedding_size(self):
+        log.debug(f"Checking embedding size for {self.collection_name} + {self.embedder_name}:")
         # having the same size does not necessarily imply being the same embedder
         # having vectors with the same size but from diffent embedder in the same vector space is wrong
         same_size = (
@@ -330,3 +334,12 @@ class VectorMemoryCollection:
                 collection_name=self.collection_name, snapshot_name=s.name
             )
         log.warning(f'Dump "{new_name}" completed')
+
+
+    def delete(self):
+        """Delete the collection from the vectorstore."""
+        return self.client.delete_collection(self.collection_name)
+    
+    def get(self):
+        """Get the collection from the vectorstore."""
+        return CollectionInfo(self.client.get_collection(self.collection_name).points_count)

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -1,94 +1,54 @@
-import sys
-import socket
-from cat.utils import extract_domain_from_url, is_https
+import os
 
-from qdrant_client import QdrantClient
+from cat.memory.elasticsearch.vector_memory import VectorMemoryES
+from cat.memory.qdrant.vector_memory import VectorMemoryQdrant
 
-from cat.memory.vector_memory_collection import VectorMemoryCollection
 from cat.log import log
-from cat.env import get_env
+
+from cat.memory.constants import COLLECTION_NAMES
+from cat.memory.collection_info import CollectionInfo
 # from cat.utils import singleton
 
 
-# @singleton REFACTOR: worth it to have this (or LongTermMemory) as singleton?
+#@singleton REFACTOR: worth it to have this (or LongTermMemory) as singleton?
 class VectorMemory:
-    local_vector_db = None
+
 
     def __init__(
-        self,
-        embedder_name=None,
-        embedder_size=None,
-    ) -> None:
-        # connects to Qdrant and creates self.vector_db attribute
-        self.connect_to_vector_memory()
+            self,
+            vector_memory_config={}
+        ) -> None:
+
+        host_type = os.getenv("HOST_TYPE", "qdrant")
+        log.info(host_type)
+        if len(host_type) == 0 or host_type == "qdrant":
+            self.vector_db = VectorMemoryQdrant(**vector_memory_config)
+        else:
+            self.vector_db = VectorMemoryES(**vector_memory_config)
 
         # Create vector collections
         # - Episodic memory will contain user and eventually cat utterances
         # - Declarative memory will contain uploaded documents' content
         # - Procedural memory will contain tools and knowledge on how to do things
-        self.collections = {}
-        for collection_name in ["episodic", "declarative", "procedural"]:
-            # Instantiate collection
-            collection = VectorMemoryCollection(
-                client=self.vector_db,
-                collection_name=collection_name,
-                embedder_name=embedder_name,
-                embedder_size=embedder_size,
-            )
-
-            # Update dictionary containing all collections
-            # Useful for cross-searching and to create/use collections from plugins
-            self.collections[collection_name] = collection
+        self.collections = self.vector_db.collections
+        for collection_name in COLLECTION_NAMES:
+            log.info(collection_name)
 
             # Have the collection as an instance attribute
             # (i.e. do things like cat.memory.vectors.declarative.something())
-            setattr(self, collection_name, collection)
+            setattr(self, collection_name, self.vector_db.collections[collection_name])
 
     def connect_to_vector_memory(self) -> None:
-        db_path = "cat/data/local_vector_memory/"
-        qdrant_host = get_env("CCAT_QDRANT_HOST")
+        """Ask the specific vector_db to connect"""
 
-        if not qdrant_host:
-            log.info(f"Qdrant path: {db_path}")
-            # Qdrant local vector DB client
-
-            # reconnect only if it's the first boot and not a reload
-            if VectorMemory.local_vector_db is None:
-                VectorMemory.local_vector_db = QdrantClient(
-                    path=db_path, force_disable_check_same_thread=True
-                )
-
-            self.vector_db = VectorMemory.local_vector_db
-        else:
-            # Qdrant remote or in other container
-            qdrant_port = int(get_env("CCAT_QDRANT_PORT"))
-            qdrant_https = is_https(qdrant_host)
-            qdrant_host = extract_domain_from_url(qdrant_host)
-            qdrant_api_key = get_env("CCAT_QDRANT_API_KEY")
-
-            try:
-                s = socket.socket()
-                s.connect((qdrant_host, qdrant_port))
-            except Exception:
-                log.error(f"QDrant does not respond to {qdrant_host}:{qdrant_port}")
-                sys.exit()
-            finally:
-                s.close()
-
-            # Qdrant vector DB client
-            self.vector_db = QdrantClient(
-                host=qdrant_host,
-                port=qdrant_port,
-                https=qdrant_https,
-                api_key=qdrant_api_key,
-            )
+        self.vector_db.connect_to_vector_memory()
 
     def delete_collection(self, collection_name: str):
         """Delete specific vector collection"""
         
         return self.vector_db.delete_collection(collection_name)
     
-    def get_collection(self, collection_name: str):
+    def get_collection(self, collection_name: str) -> CollectionInfo:
         """Get collection info"""
         
         return self.vector_db.get_collection(collection_name)

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "APScheduler==3.10.4",
     "ruff==0.4.7",
     "aiofiles==24.1.0",
+    "elasticsearch>=8.17.0"
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

This is an attempt to add an adapter for the memory storage in order to let the user configure a different vectorDB than the bundled Qdrant one.
I have 0 experience with python, so sorry about silly mistakes in this PR.

My idea was to start with something simple like configure it via `.env` file and the transition for the final user should be completely transparent.

Features planned:
* [x] ability to configure an ES host
* [x] support cloud instance
* [x] abstract the `VectorMemory` logic with an adapter
  * [x] remap all the `collection` logic into ES-specific logic
  * [x] provide lean adapters for ES results
  * [ ] provide basic knn search
  * [ ] handle the switch embedder scenario

Related to issue #1039 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
