### PR TITLE
Update rabbit_hole.py tokenizer encounters a special token (`\n`)

### DIFF
--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -53,6 +53,8 @@ class RabbitHole:
             encoding_name="cl100k_base",
             keep_separator=True,
             strip_whitespace=True,
+            allowed_special={"\n"},  # Consenti esplicitamente il token speciale '\n'
+            disallowed_special=()    # Disabilita il controllo per altri token speciali            
         )
 
         # no access to StrayCat yet

--- a/core/cat/rabbit_hole.py
+++ b/core/cat/rabbit_hole.py
@@ -53,8 +53,8 @@ class RabbitHole:
             encoding_name="cl100k_base",
             keep_separator=True,
             strip_whitespace=True,
-            allowed_special={"\n"},  # Consenti esplicitamente il token speciale '\n'
-            disallowed_special=()    # Disabilita il controllo per altri token speciali            
+            allowed_special={"\n"},  # Explicitly allow the special token ‘\n’
+            disallowed_special=()    # Disallow control for other special tokens            
         )
 
         # no access to StrayCat yet


### PR DESCRIPTION
The problem is that the tokenizer encounters a special token (`\n`) that is not allowed by default, causing an error. To fix it, we explicitly allow `\n` using `allowed_special={"\n"}` and disable checks for other special tokens with `disallowed_special=()` .

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related to issue #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
