### PR TITLE
classify score_threshold as parameter, default 0.5, instead of magic …

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -575,7 +575,7 @@ class StrayCat:
                     log.warning(ex)
 
     def classify(
-        self, sentence: str, labels: List[str] | Dict[str, List[str]]
+        self, sentence: str, labels: List[str] | Dict[str, List[str]], score_threshold: float = 0.5
     ) -> str | None:
         """Classify a sentence.
 
@@ -635,8 +635,7 @@ Allowed classes are:
             key=lambda x: x[1],
         )
 
-        # set 0.5 as threshold - let's see if it works properly
-        return best_label if score < 0.5 else None
+        return best_label if score < score_threshold else None
 
     def langchainfy_chat_history(self, latest_n: int = 20) -> List[BaseMessage]:
         """Redirects to WorkingMemory.langchainfy_chat_history. Will be removed from this class in v2."""


### PR DESCRIPTION
# Description

This pull request introduces a configurable score_threshold parameter to the classify method.
Previously, the threshold for accepting a classification was hardcoded to 0.5. With this change, users can specify a custom threshold at call time, making the method more flexible for different confidence requirements.

This change maintains backward compatibility by setting the default threshold to 0.5.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
