### PR TITLE
Add configurable timeout for Qdrant client

### DIFF
--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -24,6 +24,7 @@ def get_supported_env_variables():
         "CCAT_CORS_ENABLED": "true",
         "CCAT_CACHE_TYPE": "in_memory",
         "CCAT_CACHE_DIR": "/tmp",
+        "CCAT_QDRANT_CLIENT_TIMEOUT": None,
     }
 
 

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -65,6 +65,9 @@ class VectorMemory:
             qdrant_https = is_https(qdrant_host)
             qdrant_host = extract_domain_from_url(qdrant_host)
             qdrant_api_key = get_env("CCAT_QDRANT_API_KEY")
+            
+            qdrant_client_timeout = get_env("CCAT_QDRANT_CLIENT_TIMEOUT")
+            qdrant_client_timeout = int(qdrant_client_timeout) if qdrant_client_timeout is not None else None
 
             try:
                 s = socket.socket()
@@ -81,6 +84,7 @@ class VectorMemory:
                 port=qdrant_port,
                 https=qdrant_https,
                 api_key=qdrant_api_key,
+                timeout=qdrant_client_timeout
             )
 
     def delete_collection(self, collection_name: str):

--- a/core/cat/memory/vector_memory_collection.py
+++ b/core/cat/memory/vector_memory_collection.py
@@ -95,7 +95,7 @@ class VectorMemoryCollection:
     # create collection
     def create_collection(self):
         log.warning(f'Creating collection "{self.collection_name}" ...')
-        self.client.recreate_collection(
+        self.client.create_collection(
             collection_name=self.collection_name,
             vectors_config=VectorParams(
                 size=self.embedder_size, distance=Distance.COSINE
@@ -107,7 +107,6 @@ class VectorMemoryCollection:
                     type=ScalarType.INT8, quantile=0.95, always_ram=True
                 )
             ),
-            # shard_number=3,
         )
 
         self.client.update_collection_aliases(
@@ -219,9 +218,9 @@ class VectorMemoryCollection:
     ):
         """Retrieve similar memories from embedding"""
 
-        memories = self.client.search(
+        memories = self.client.query_points(
             collection_name=self.collection_name,
-            query_vector=embedding,
+            query=embedding,
             query_filter=self._qdrant_filter_from_dict(metadata),
             with_payload=True,
             with_vectors=True,
@@ -234,7 +233,7 @@ class VectorMemoryCollection:
                     oversampling=2.0,  # Available as of v1.3.0
                 )
             ),
-        )
+        ).points
 
         # convert Qdrant points to langchain.Document
         langchain_documents_from_points = []

--- a/core/cat/memory/vector_memory_collection.py
+++ b/core/cat/memory/vector_memory_collection.py
@@ -59,11 +59,11 @@ class VectorMemoryCollection:
             == self.embedder_size
         )
         alias = self.embedder_name + "_" + self.collection_name
-        if (
-            alias
-            == self.client.get_collection_aliases(self.collection_name)
-            .aliases[0]
-            .alias_name
+
+        existing_aliases = self.client.get_collection_aliases(self.collection_name).aliases
+
+        if ( len(existing_aliases) > 0 and
+            alias == existing_aliases[0].alias_name
             and same_size
         ):
             log.debug(f'Collection "{self.collection_name}" has the same embedder')
@@ -94,6 +94,7 @@ class VectorMemoryCollection:
 
     # create collection
     def create_collection(self):
+<<<<<<< Updated upstream
         log.warning(f'Creating collection "{self.collection_name}" ...')
         self.client.create_collection(
             collection_name=self.collection_name,
@@ -115,10 +116,51 @@ class VectorMemoryCollection:
                     create_alias=CreateAlias(
                         collection_name=self.collection_name,
                         alias_name=self.embedder_name + "_" + self.collection_name,
+=======
+        try:
+            log.warning(f'Creating collection "{self.collection_name}" ...')
+            self.client.recreate_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(
+                    size=self.embedder_size, distance=Distance.COSINE
+                ),
+                # hybrid mode: original vector on Disk, quantized vector in RAM
+                optimizers_config=OptimizersConfigDiff(memmap_threshold=20000),
+                quantization_config=ScalarQuantization(
+                    scalar=ScalarQuantizationConfig(
+                        type=ScalarType.INT8, quantile=0.95, always_ram=True
+>>>>>>> Stashed changes
                     )
-                )
-            ]
-        )
+                ),
+                # shard_number=3,
+            )
+        except Exception as e:
+            log.error(f"Error creating collection {self.collection_name}. Try setting a higher timeout value in CCAT_QDRANT_CLIENT_TIMEOUT: {e}")
+            self.client.delete_collection(self.collection_name)
+            raise
+
+        try:
+            alias_name=self.embedder_name + "_" + self.collection_name
+            log.warning(f'Creating alias {alias_name} for collection "{self.collection_name}" ...')
+
+            self.client.update_collection_aliases(
+                change_aliases_operations=[
+                    CreateAliasOperation(
+                        create_alias=CreateAlias(
+                            collection_name=self.collection_name,
+                            alias_name=self.embedder_name + "_" + self.collection_name,
+                        )
+                    )
+                ]
+            )
+
+            log.warning(f'Created alias {alias_name} for collection "{self.collection_name}" ...')
+        except Exception as e:
+            log.error(f"Error creating collection alias {alias_name} for collection {self.collection_name}: {e}")
+            self.client.delete_collection(self.collection_name)
+            log.error(f" collection {self.collection_name} deleted")
+            raise
+
 
     # adapted from https://github.com/langchain-ai/langchain/blob/bfc12a4a7644cfc4d832cc4023086a7a5374f46a/libs/langchain/langchain/vectorstores/qdrant.py#L1965
     def _qdrant_filter_from_dict(self, filter: dict) -> Filter:

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -296,7 +296,7 @@ def langchain_log_prompt(langchain_prompt, title):
         print(get_colored_text(f"===== {title} =====", "green"))
         for m in langchain_prompt.messages:
             print(get_colored_text(type(m).__name__, "green"))
-            if type(m.content) == list:
+            if isinstance(m.content, list):
                 for sub_m in m.content:
                     if sub_m.get("type") == "text":
                         print(sub_m["text"])

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Cheshire-Cat"
 description = "Production ready AI assistant framework"
-version = "1.8.1"
+version = "1.9.0"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [


### PR DESCRIPTION

## Description

This PR adds the ability to configure timeouts for operations with the Qdrant vector database client. When creating collections on Qdrant, especially in environments with limited resources, the default timeout may not be sufficient, causing operations to fail during the startup phase.

The change adds a new environment variable `CCAT_QDRANT_CLIENT_TIMEOUT` that allows users to specify a custom timeout value (in seconds) for Qdrant client operations, particularly useful during collection creation.

This helps prevent issues when creating collections in resource-constrained environments or when working with very large vector dimensions.

Related to issue #849

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
