### PR TITLE
Added CCAT_QDRANT_CLIENT_TIMEOUT environment parameter to configure Q…

### DIFF
--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -24,6 +24,7 @@ def get_supported_env_variables():
         "CCAT_CORS_ENABLED": "true",
         "CCAT_CACHE_TYPE": "in_memory",
         "CCAT_CACHE_DIR": "/tmp",
+        "CCAT_QDRANT_CLIENT_TIMEOUT": None,
     }
 
 

--- a/core/cat/memory/vector_memory.py
+++ b/core/cat/memory/vector_memory.py
@@ -65,6 +65,9 @@ class VectorMemory:
             qdrant_https = is_https(qdrant_host)
             qdrant_host = extract_domain_from_url(qdrant_host)
             qdrant_api_key = get_env("CCAT_QDRANT_API_KEY")
+            
+            qdrant_client_timeout = get_env("CCAT_QDRANT_CLIENT_TIMEOUT")
+            qdrant_client_timeout = int(qdrant_client_timeout) if qdrant_client_timeout is not None else None
 
             try:
                 s = socket.socket()
@@ -81,6 +84,7 @@ class VectorMemory:
                 port=qdrant_port,
                 https=qdrant_https,
                 api_key=qdrant_api_key,
+                timeout=qdrant_client_timeout
             )
 
     def delete_collection(self, collection_name: str):


### PR DESCRIPTION
This PR adds the ability to configure timeouts for operations with the Qdrant vector database client. When creating collections on Qdrant, especially in environments with limited resources, the default timeout may not be sufficient, causing operations to fail during the startup phase.

The change adds a new environment variable CCAT_QDRANT_CLIENT_TIMEOUT that allows users to specify a custom timeout value (in seconds) for Qdrant client operations, particularly useful during collection creation.

This helps prevent issues when creating collections in resource-constrained environments or when working with very large vector dimensions.

Documentation will need to be updated to include this new configuration parameter and its default value of the quadrant client timeout (5) in the environment variables section

Related to issue https://github.com/cheshire-cat-ai/core/issues/849


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

