### PR TITLE
Improves plugin validation and handles duplicates

### DIFF
--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -30,11 +30,11 @@ async def get_available_plugins(
     for p in registry_plugins:
         plugin_url = p.get("plugin_url", None)
         if plugin_url is None:
-            log.warning(f"Plugin {p.get('name')} has no `plugin_url`. It will be skipped from the plugins list.")
+            log.warning(f"Plugin {p.get('name')} has no `plugin_url`. It will be skipped from the registry list.")
             continue
-        url = p.get("url", None)
-        if url and url != plugin_url:
-            log.warning(f"Plugin {p.get('name')} has `url` {url} different from `plugin_url` {plugin_url}. please check the plugin.")
+        # url = p.get("url", None)
+        # if url and url != plugin_url:
+        #     log.info(f"Plugin {p.get('name')} has `url` {url} different from `plugin_url` {plugin_url}. please check the plugin.")
         if plugin_url in registry_plugins_index:
             current = registry_plugins_index[plugin_url]
             log.warning(f"duplicate plugin_url {plugin_url} found in registry. Plugins {p.get('name')} has same url than {current.get('name')}. Skipping.")

--- a/core/cat/routes/plugins.py
+++ b/core/cat/routes/plugins.py
@@ -28,7 +28,18 @@ async def get_available_plugins(
     # index registry plugins by url
     registry_plugins_index = {}
     for p in registry_plugins:
-        plugin_url = p["url"]
+        plugin_url = p.get("plugin_url", None)
+        if plugin_url is None:
+            log.warning(f"Plugin {p.get('name')} has no `plugin_url`. It will be skipped from the plugins list.")
+            continue
+        url = p.get("url", None)
+        if url and url != plugin_url:
+            log.warning(f"Plugin {p.get('name')} has `url` {url} different from `plugin_url` {plugin_url}. please check the plugin.")
+        if plugin_url in registry_plugins_index:
+            current = registry_plugins_index[plugin_url]
+            log.warning(f"duplicate plugin_url {plugin_url} found in registry. Plugins {p.get('name')} has same url than {current.get('name')}. Skipping.")
+            continue    
+
         registry_plugins_index[plugin_url] = p
 
     # get active plugins
@@ -53,18 +64,19 @@ async def get_available_plugins(
         manifest["endpoints"] = [{"name": endpoint.name, "tags": endpoint.tags} for endpoint in p.endpoints]
         manifest["forms"] = [{"name": form.name} for form in p.forms]
 
+        # do not show already installed plugins among registry plugins
+        r = registry_plugins_index.pop(manifest["plugin_url"], None)
+        
         # filter by query
         plugin_text = [str(field) for field in manifest.values()]
         plugin_text = " ".join(plugin_text).lower()
-        if (query is None) or (query.lower() in plugin_text):
-            for r in registry_plugins:
-                if r["plugin_url"] == p.manifest["plugin_url"]:
-                    if r["version"] != p.manifest["version"]:
-                        manifest["upgrade"] = r["version"]
-            installed_plugins.append(manifest)
 
-        # do not show already installed plugins among registry plugins
-        registry_plugins_index.pop(manifest["plugin_url"], None)
+        if (query is None) or (query.lower() in plugin_text):
+            if r is not None:
+                r_version = r.get("version", None)
+                if r_version is not None and r_version != p.manifest.get("version"):
+                    manifest["upgrade"] = r["version"]
+            installed_plugins.append(manifest)
 
     return {
         "filters": {


### PR DESCRIPTION
# Description

Fixes https://github.com/cheshire-cat-ai/core/issues/1067

Enhances plugin URL validation by skipping entries without a URL or with duplicate URLs, logging warnings for skipped plugins. Ensures installed plugins are removed from the registry list and checks for version upgrades more robustly.

Refines filtering logic for better query handling and maintains clarity in plugin management.


Related to issue #1067

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
