### PR TITLE
Fix escape characters in utils.parse_json

### DIFF
--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -171,8 +171,8 @@ def parse_json(json_string: str, pydantic_model: BaseModel = None) -> dict:
 
     # clean to help small LLMs
     replaces = {
-        "\_": "_",
-        "\-": "-",
+        "\\_": "_",
+        "\\-": "-",
         "None": "null",
         "{{": "{",
         "}}": "}",


### PR DESCRIPTION
# Description  
**Fix invalid escape sequences in `utils.py` (`parse_json`)**  

In `utils.py`, the `parse_json` function attempts to replace `\_` and `\-`, but to represent literal backslashes in strings, they must be escaped themselves (`\\`).

## Error Produced:  
When importing `utils.py` in a Python shell, the following warnings appear:  
```
.../core/cat/utils.py:174: SyntaxWarning: invalid escape sequence '\_'
  "\_": "_",
.../core/cat/utils.py:175: SyntaxWarning: invalid escape sequence '\-'
  "\-": "-",
```

## Changes Made:  
- Replaced `"\_"` with `"\\_"` and `"\-"` with `"\\-"` to correctly escape the backslashes.  

### Before:  
```python
replaces = {
    "\_": "_",  # Invalid escape
    "\-": "-",  # Invalid escape
    "None": "null",
    "{{": "{",
    "}}": "}",
}
```

### After:  
```python
replaces = {
    "\\_": "_",  # Correctly escaped
    "\\-": "-",  # Correctly escaped
    "None": "null",
    "{{": "{",
    "}}": "}",
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
