### PR TITLE
Levenshtein distance without langchain

### DIFF
--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -7,7 +7,8 @@ from urllib.parse import urlparse
 from typing import Dict, Tuple
 from pydantic import BaseModel, ConfigDict
 
-from langchain.evaluation import StringDistance, load_evaluator, EvaluatorType
+from rapidfuzz.fuzz import ratio
+from rapidfuzz.distance import Levenshtein
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_core.utils import get_colored_text
@@ -155,15 +156,8 @@ def deprecation_warning(message: str, skip=3):
 
 
 def levenshtein_distance(prediction: str, reference: str) -> int:
-    jaro_evaluator = load_evaluator(
-        EvaluatorType.STRING_DISTANCE, distance=StringDistance.LEVENSHTEIN
-    )
-    result = jaro_evaluator.evaluate_strings(
-        prediction=prediction,
-        reference=reference,
-    )
-    return result["score"]
-
+    res = Levenshtein.normalized_distance(prediction, reference)
+    return res
 
 def parse_json(json_string: str, pydantic_model: BaseModel = None) -> dict:
     # instantiate parser


### PR DESCRIPTION
# Description

Use the Levenshtein implementation from `rapidfuzz` instead of the one from LangChain.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
