### PR TITLE
Use official langchain cohere

### DIFF
--- a/core/cat/looking_glass/cheshire_cat.py
+++ b/core/cat/looking_glass/cheshire_cat.py
@@ -7,7 +7,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers.string import StrOutputParser
-from langchain_community.llms import Cohere
+from langchain_cohere import ChatCohere
 from langchain_openai import ChatOpenAI, OpenAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 
@@ -208,7 +208,7 @@ class CheshireCat:
         # For Azure avoid automatic embedder selection
 
         # Cohere
-        elif type(self._llm) in [Cohere]:
+        elif type(self._llm) in [ChatCohere]:
             embedder = embedders.EmbedderCohereConfig.get_embedder_from_config(
                 {
                     "cohere_api_key": self._llm.cohere_api_key,


### PR DESCRIPTION
# Description

Use official langchain `CohereChat` from `langchain_cohere` package instead of `langchain_community` as in [llm factory](https://github.com/cheshire-cat-ai/core/blob/8c6238e1938546c0bdb5c97e22787652e1c04c62/core/cat/factory/llm.py#L182)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
