### PR TITLE
Fix for cleared chat history reloaded by stateful cache managers 

### DIFF
--- a/core/cat/routes/websocket/websocket.py
+++ b/core/cat/routes/websocket/websocket.py
@@ -43,9 +43,9 @@ async def websocket_endpoint(
     except WebSocketDisconnect:
         log.info(f"WebSocket connection closed for user {cat.user_id}")
     finally:
-        
+
         # cat's working memory in this scope has not been updated
-        #cat.load_working_memory_from_cache()
-        
+        cat.load_working_memory_from_cache()
+
         # Remove connection on disconnect
         websocket_manager.remove_connection(cat.user_id)

--- a/core/cat/utils.py
+++ b/core/cat/utils.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 from typing import Dict, Tuple
 from pydantic import BaseModel, ConfigDict
 
-from rapidfuzz.fuzz import ratio
 from rapidfuzz.distance import Levenshtein
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
@@ -146,7 +145,7 @@ HOW TO FIX: go to your OpenAI accont and add a credit card"""
 def deprecation_warning(message: str, skip=3):
     """Log a deprecation warning with caller's information.
         "skip" is the number of stack levels to go back to the caller info."""
-    
+
     caller = get_caller_info(skip, return_short=False)
 
     # Format and log the warning message
@@ -179,7 +178,7 @@ def parse_json(json_string: str, pydantic_model: BaseModel = None) -> dict:
 
     # parse
     parsed = parser.parse(json_string[start_index:])
-    
+
     if pydantic_model:
         return pydantic_model(**parsed)
     return parsed
@@ -207,7 +206,7 @@ def match_prompt_variables(
             prompt_template = \
                 prompt_template.replace("{" + m + "}", "")
             log.debug(f"Placeholder '{m}' not found in prompt variables, removed")
-            
+
     return prompt_variables, prompt_template
 
 
@@ -249,7 +248,7 @@ def get_caller_info(skip=2, return_short=True, return_string=True):
     start = 0 + skip
     if len(stack) < start + 1:
         return None
-    
+
     parentframe = stack[start][0]
 
     # module and packagename.
@@ -341,7 +340,7 @@ class BaseModelDict(BaseModel):
     def __getitem__(self, key):
         # deprecate dictionary usage
         deprecation_warning(
-            f'To get `{key}` use dot notation instead of dictionary keys, example:' 
+            f'To get `{key}` use dot notation instead of dictionary keys, example:'
             f'`obj.{key}` instead of `obj["{key}"]`'
         )
 

--- a/core/tests/cache/test_core_caches.py
+++ b/core/tests/cache/test_core_caches.py
@@ -16,18 +16,23 @@ def create_cache(cache_type):
         assert False
 
 
+
 @pytest.mark.parametrize("cache_type", ["in_memory", "file_system"])
 def test_cache_creation(cache_type):
+    try:
+        cache = create_cache(cache_type)
 
-    cache = create_cache(cache_type)
-    
-    if cache_type == "in_memory":
-        assert cache.items == {}
-        assert cache.max_items == 100
-    else:
-        assert cache.cache_dir == "/tmp_cache"
-        assert os.path.exists("/tmp_cache")
-        assert os.listdir("/tmp_cache") == []
+        if cache_type == "in_memory":
+            assert cache.items == {}
+            assert cache.max_items == 100
+        else:
+            assert cache.cache_dir == "/tmp_cache"
+            assert os.path.exists("/tmp_cache")
+            assert os.listdir("/tmp_cache") == []
+    finally:
+        import shutil
+        if os.path.exists("/tmp_cache"):
+            shutil.rmtree("/tmp_cache")
 
 
 @pytest.mark.parametrize("cache_type", ["in_memory", "file_system"])
@@ -36,13 +41,13 @@ def test_cache_get_insert(cache_type):
     cache = create_cache(cache_type)
 
     assert cache.get_item("a") is None
-    
-    c1 = CacheItem("a", [])  
+
+    c1 = CacheItem("a", [])
     cache.insert(c1)
     assert cache.get_item("a").value == []
     assert cache.get_value("a") == []
 
-        
+
     c1.value = [0]
     cache.insert(c1) # will be overwritten
     assert cache.get_item("a").value == [0]
@@ -64,7 +69,7 @@ def test_cache_delete(cache_type):
 
     c1 = CacheItem("a", [])
     cache.insert(c1)
-    
+
     cache.delete("a")
     assert cache.get_item("a") is None
 


### PR DESCRIPTION
# Description

Fix for the issue https://github.com/cheshire-cat-ai/core/issues/1075

From the Cat UI, when using file_system as a cache manager, if you wipe a conversation using HTTP DELETE /conversation_history and then do a browser refresh, the deleted conversation is loaded back from the cache.


The bug was introduced in [this commit](https://github.com/cheshire-cat-ai/core/commit/81e24d8885632ff60a818e72bdbe60ebeaddb589#diff-aaccca9665b8793ba62947e177372c195f6de3c21394b7692ecfd475e984cdddR48) in the file `websocket.py`, commenting the line 48

I noticed that this commit also modified the test `test_session_sync_while_websocket_is_open` in the file `core/tests/routes/test_session.py`. I checked that uncommenting the line 48 in `websocket.py` was not breaking it. It doesn't.

Related to tests, `test_cache_creation` in `core/tests/cache/test_core_caches.py` was failing on a second test run. This happens also in the main branch, due to a dirty context issue. I then added a try/finally block to clear the context and fix the test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
