### PR TITLE
Add New PUT Endpoint /conversation_history/

### DIFF
--- a/core/cat/memory/working_memory.py
+++ b/core/cat/memory/working_memory.py
@@ -86,16 +86,28 @@ class WorkingMemory(BaseModelDict):
 
         self.history.append(content)
 
-    def update_history(self, message: ConversationMessage):
+    def update_history(self, message: ConversationMessage, index: int = None):
         """
-        Adds a message to the history.
+        Adds a message to the history or updates an existing message if an index is provided.
 
         Parameters
         ----------
         message : ConversationMessage
             The message, must be of type `ConversationMessage` (typically a subclass like `UserMessage` or `CatMessage`).
+        index : int, optional
+            The index at which to modify the message in the history. Defaults to None (appends a new message).
         """
-        self.history.append(message)
+
+        if index is None:
+            # index is None append to history
+            self.history.append(message)
+        else:
+            # check index value
+            if index >= len(self.history) or index < -len(self.history):
+                raise Exception(f"Index {index} is out of bounds for history of length {len(self.history)}.")
+            
+            self.history[index] = message 
+        
         self.history = self.history[-MAX_WORKING_HISTORY_LENGTH:]
 
 

--- a/core/cat/routes/memory/convo_history.py
+++ b/core/cat/routes/memory/convo_history.py
@@ -2,7 +2,6 @@
 
 from typing import Dict
 from fastapi import Request, APIRouter, HTTPException
-from pydantic import BaseModel
 
 from cat.auth.permissions import AuthPermission, AuthResource, check_permissions
 from cat.looking_glass.stray_cat import StrayCat

--- a/core/cat/routes/memory/convo_history.py
+++ b/core/cat/routes/memory/convo_history.py
@@ -1,14 +1,15 @@
 
 
 from typing import Dict
-from fastapi import Request, APIRouter
+from fastapi import Request, APIRouter, HTTPException
+from pydantic import BaseModel
 
 from cat.auth.permissions import AuthPermission, AuthResource, check_permissions
 from cat.looking_glass.stray_cat import StrayCat
+from cat.convo.messages import ConversationMessage, Role, CatMessage, UserMessage
 
 
 router = APIRouter()
-
 
 # DELETE conversation history from working memory
 @router.delete("/conversation_history")
@@ -36,3 +37,57 @@ async def get_conversation_history(
     return {"history": cat.working_memory.history}
 
 
+# PUT conversation history from working memory
+@router.put("/conversation_history/{conversation_history_index}")
+async def put_conversation_history(
+    request: Request,
+    conversation_history_index: int,
+    history_message: ConversationMessage,
+    stray: StrayCat = check_permissions(AuthResource.MEMORY, AuthPermission.EDIT),
+) -> Dict:
+    """Edit a conversation history in working memory in a specified index. Supports negative indexing for reverse access.
+    
+    Example
+    ----------
+    ```
+    # overwrite last history message
+    req_json = {
+        "who": "Human",
+        "text": "MIAO!",
+        "user_id": "123"
+    }
+    res = requests.put(
+        "http://localhost:1865/memory/conversation_history/-1", json=req_json
+    )
+
+    # overwrite first history message
+    req_json = requests.get("http://localhost:1865/memory/conversation_history")
+    req_json = req_json.json()["history"][0]
+
+    req_json["text"] = "MIAO!"
+    res = requests.put(
+        "http://localhost:1865/memory/conversation_history/0", json=req_json
+    )
+    ```
+    """
+
+    working_memory = stray.working_memory 
+    history = working_memory.history
+
+    if conversation_history_index < -len(history) or conversation_history_index >= len(history):
+        raise HTTPException(
+            status_code=400, detail={"error": f"Invalid conversation history index. Index out of range. Please use a valid -{len(working_memory.history)} < index < {len(working_memory.history)}."}
+        )
+    
+    if history_message.who == Role.AI:
+        history_message = CatMessage(**history_message.model_dump())
+    else:
+        history_message = UserMessage(**history_message.model_dump())
+
+    working_memory.update_history(history_message, conversation_history_index)
+
+    # if conversation_history_index is None return the last message in the history
+    if conversation_history_index is None:
+        conversation_history_index = -1
+
+    return history[conversation_history_index].model_dump()

--- a/core/tests/memory/test_class_working_memory.py
+++ b/core/tests/memory/test_class_working_memory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from langchain_core.messages import AIMessage, HumanMessage
 
 from cat.convo.messages import Role, UserMessage, CatMessage
@@ -44,6 +46,54 @@ def test_update_history():
     assert wm.history[1].who == "AI"
     assert wm.history[1].role == Role.AI
     assert wm.history[1].text == "Meow"
+
+
+def test_update_history_with_index():
+
+    wm = create_working_memory_with_convo_history(turns=2)
+
+    # test negative index
+    human_message = UserMessage(user_id="123", who="Human", text="Hello")
+    wm.update_history(human_message, index = -4)
+    cat_message = CatMessage(user_id="123", who="AI", text="Meow Update!!!")
+    wm.update_history(cat_message, index = -1)
+
+    assert len(wm.history) == 4
+
+    assert isinstance(wm.history[0], UserMessage)
+    assert wm.history[0].who == "Human"
+    assert wm.history[0].role == Role.Human
+    assert wm.history[0].text == "Hello"
+
+    assert isinstance(wm.history[3], CatMessage)
+    assert wm.history[3].who == "AI"
+    assert wm.history[3].role == Role.AI
+    assert wm.history[3].text == "Meow Update!!!"
+
+    # test positive index
+    cat_message = CatMessage(user_id="123", who="AI", text="Meow!")
+    wm.update_history(cat_message, index = 0)
+    human_message = UserMessage(user_id="123", who="Human", text="Hi!")
+    wm.update_history(human_message, index = 3)
+
+    assert isinstance(wm.history[0], CatMessage)
+    assert wm.history[0].who == "AI"
+    assert wm.history[0].role == Role.AI
+    assert wm.history[0].text == "Meow!"
+
+    assert isinstance(wm.history[3], UserMessage)
+    assert wm.history[3].who == "Human"
+    assert wm.history[3].role == Role.Human
+    assert wm.history[3].text == "Hi!"
+
+    with pytest.raises(Exception) as excinfo:
+        wm.update_history(human_message, index = 4)
+    assert  "Index 4 is out of bounds for history of length 4" in str(excinfo)
+
+    with pytest.raises(Exception) as excinfo:
+        wm.update_history(human_message, index = -5)
+    assert  "Index -5 is out of bounds for history of length 4" in str(excinfo)
+
 
 
 def test_history_max_length():


### PR DESCRIPTION
# Description

This PR create a new PUT endpoint  /conversation_history/{index} that accept a ConversationMessage  to impose a conversation history (GET and DELETE already exists).

Usage example:
```
req_json = requests.get("http://localhost:1865/memory/conversation_history")
 req_json = req_json.json()["history"][0]

 req_json["text"] = "MIAO!"
 res = requests.put(
 "http://localhost:1865/memory/conversation_history/0", json=req_json
 )
```

Related to issue #896

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
