### PR TITLE
Add a new env to manage /admin directory

### DIFF
--- a/core/cat/env.py
+++ b/core/cat/env.py
@@ -24,6 +24,7 @@ def get_supported_env_variables():
         "CCAT_CORS_ENABLED": "true",
         "CCAT_CACHE_TYPE": "in_memory",
         "CCAT_CACHE_DIR": "/tmp",
+        "CCAT_ADMIN_DIR": "/admin"
     }
 
 

--- a/core/cat/routes/static/admin.py
+++ b/core/cat/routes/static/admin.py
@@ -5,6 +5,7 @@ from fastapi import Depends
 from cat.auth.permissions import AuthResource, AuthPermission
 from cat.auth.connection import CoreFrontendAuth
 from cat.looking_glass.stray_cat import StrayCat
+from cat.env import get_env
 
 
 def mount(cheshire_cat_api):
@@ -12,7 +13,7 @@ def mount(cheshire_cat_api):
     mount_admin_spa(cheshire_cat_api)
 
     # note html=False because index.html needs to be injected with runtime information
-    cheshire_cat_api.mount("/admin", StaticFiles(directory="/admin/"), name="admin")
+    cheshire_cat_api.mount("/admin", StaticFiles(directory=get_env("CCAT_ADMIN_DIR")), name="admin")
 
 
 def mount_admin_spa(cheshire_cat_api):
@@ -28,4 +29,4 @@ def mount_admin_spa(cheshire_cat_api):
         # the admin static build is created during docker build from this repo:
         # https://github.com/cheshire-cat-ai/admin-vue
         # the files live inside the /admin folder (not visible in volume / cat code)
-        return FileResponse("/admin/index.html")
+        return FileResponse(get_env("CCAT_ADMIN_DIR") +"/index.html")


### PR DESCRIPTION
# Description

The /admin directory is hardcoded to be in the root. Root directory is not available to users in unix systems so I added an environment variable (defaulting to the previous value) to be able to configure a different path.

Related to issue #1083

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
