### PR TITLE
Use env port configuration in uvicorn

### DIFF
--- a/core/cat/main.py
+++ b/core/cat/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     uvicorn.run(
         "cat.startup:cheshire_cat_api",
         host="0.0.0.0",
-        port=80,
+        port=int(get_env("CCAT_CORE_PORT")),
         use_colors=True,
         log_level=get_env("CCAT_LOG_LEVEL").lower(),
         **debug_config,


### PR DESCRIPTION
# Description

The project starts by default a server listening on TCP/80 which is not user available on unix systems and even if an environment variable is available to configure that (CCAT_CORE_PORT) it's not used. This fix set the port to what is set in the environment variable CCAT_CORE_PORT.

Related to issue #1087 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
