### PR TITLE
Feat/issue 1081

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ class PizzaForm(CatForm):
 
 ## Roadmap & Contributing
 
+*Attention*: while version 2 is being worked out, we'll only accept bug fixes for v1. Send your PR for v1 on branch `develop`.
+Do not expect to see merged PRs not previously discussed and agreed upon in an issue.
+
 Detailed roadmap is [here](./ROADMAP.md).  
 Send your pull request to the `develop` branch. Here is a [full guide to contributing](./CONTRIBUTING.md).
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get install -y curl build-essential fastjar libmagi
 
 ### ADMIN (static build) ###
 WORKDIR /admin
-RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/develop.zip | jar -xv
+RUN curl -sL https://github.com/cheshire-cat-ai/admin-vue/releases/download/Admin/release.zip | jar -xv
 
 ### PREPARE BUILD WITH NECESSARY FILES AND FOLDERS ###
 COPY ./pyproject.toml /app/pyproject.toml

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -56,7 +56,7 @@ class EmbedderDumbConfig(EmbedderSettings):
 
 
 class EmbedderOpenAICompatibleConfig(EmbedderSettings):
-    oai_comp_api_key: str
+    oai_comp_api_key: str = None # optional
     url: str
     _pyclass: Type = CustomOpenAIEmbeddings
 

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -56,6 +56,7 @@ class EmbedderDumbConfig(EmbedderSettings):
 
 
 class EmbedderOpenAICompatibleConfig(EmbedderSettings):
+    oai_comp_api_key: str
     url: str
     _pyclass: Type = CustomOpenAIEmbeddings
 


### PR DESCRIPTION
# Description

I added `oai_comp_api_key` to `EmbedderOpenAICompatibleConfig`. 

I set it as `None` because since it was absent until now I assumed you wanted to keep it as an optional field.

Related to issue #1081 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
