### PR TITLE
Improved classify prompt

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -625,7 +625,7 @@ class StrayCat:
 Allowed classes are:
 {labels_list}{examples_list}
 
-"{sentence}" -> """
+Just output the class, nothing else."""
 
         response = self.llm(prompt)
 


### PR DESCRIPTION
# Description

StrayCat method `classify` sometimes returns incorrect results because LLMs generate verbose explanation in the output instead of just providing the resulting class. From my experience this is true especially with larger and more powerful models, probably too chatty in their cleverness.

Just improved the prompt with a little instruction to the LLM to provide simple and parsable output.

Tested with:

- `llama3.2:3b`
- `qwen2.5:7b`
- `gemma3:4b`
- `gemma3:12b`
- `gpt-4.1-nano-2025-04-14`
- `gemini-2.5-flash-lite-preview-06-17`
- `claude-3-7-sonnet-20250219`
- `command-r7b-12-2024`

Related to issue #1091 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
