### PR TITLE
Feature/cat image only once

### DIFF
--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -4,6 +4,8 @@ import logging
 import sys
 import json
 import traceback
+import os
+from pathlib import Path
 from pprint import pformat
 from loguru import logger
 
@@ -143,24 +145,43 @@ class CatLogEngine:
         for line in lines:
             logger.log(level, line)
 
+    def _get_welcome_flag_path(self):
+        """Get the path for the welcome flag file."""
+        # Store in a temporary directory or project root
+        return Path(".welcome_shown")
+
+    def _has_welcome_been_shown(self):
+        """Check if welcome message has been shown in this session."""
+        flag_file = self._get_welcome_flag_path()
+        return flag_file.exists()
+
+    def _mark_welcome_as_shown(self):
+        """Mark welcome message as shown."""
+        flag_file = self._get_welcome_flag_path()
+        flag_file.touch()
+
     def welcome(self):
-        """Welcome message in the terminal."""
+        """Welcome message in the terminal."""        
+
+        # Show full welcome message with ASCII art
         secure = "s" if get_env("CCAT_CORE_USE_SECURE_PROTOCOLS") in ("true", "1") else ""
 
         cat_host = get_env("CCAT_CORE_HOST")
         cat_port = get_env("CCAT_CORE_PORT")
         cat_address = f"http{secure}://{cat_host}:{cat_port}"
 
-        print("\n\n")
-        with open("cat/welcome.txt", "r") as f:
-            print(f.read())
+        # Print ASCII art only if welcome has not been shown
+        if not self._has_welcome_been_shown():
+            print("\n\n")
+            with open("cat/welcome.txt", "r") as f:
+                print(f.read())
 
         left_margin = " " * 15
         print(f"\n\n{left_margin} Cat REST API:   {cat_address}/docs")
         print(f"{left_margin} Cat ADMIN:      {cat_address}/admin\n\n")
 
-        # self.log_examples()
-
+        # Mark welcome as shown
+        self._mark_welcome_as_shown()
 
     def log_examples(self):
         """Log examples for the log engine."""

--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -147,7 +147,6 @@ class CatLogEngine:
 
     def _get_welcome_flag_path(self):
         """Get the path for the welcome flag file."""
-        # Store in a temporary directory or project root
         return Path(".welcome_shown")
 
     def _has_welcome_been_shown(self):
@@ -163,25 +162,24 @@ class CatLogEngine:
     def welcome(self):
         """Welcome message in the terminal."""        
 
-        # Show full welcome message with ASCII art
+        # Show full welcome message with ASCII cat
         secure = "s" if get_env("CCAT_CORE_USE_SECURE_PROTOCOLS") in ("true", "1") else ""
 
         cat_host = get_env("CCAT_CORE_HOST")
         cat_port = get_env("CCAT_CORE_PORT")
         cat_address = f"http{secure}://{cat_host}:{cat_port}"
 
-        # Print ASCII art only if welcome has not been shown
+        # Print ASCII cat only if welcome has not been shown already
         if not self._has_welcome_been_shown():
             print("\n\n")
             with open("cat/welcome.txt", "r") as f:
                 print(f.read())
+            # Mark welcome as already shown
+            self._mark_welcome_as_shown()
 
         left_margin = " " * 15
         print(f"\n\n{left_margin} Cat REST API:   {cat_address}/docs")
         print(f"{left_margin} Cat ADMIN:      {cat_address}/admin\n\n")
-
-        # Mark welcome as shown
-        self._mark_welcome_as_shown()
 
     def log_examples(self):
         """Log examples for the log engine."""


### PR DESCRIPTION
# Fix: Show welcome ASCII cat only at launch

## Problem
The welcome ASCII cat art was displayed every time the application reloaded, which made development less pleasant.

## Solution
Implemented a session-based flag system that tracks whether the welcome message has been shown:

- Added `.welcome_shown` flag file to track display status
- Welcome ASCII art now only appears on first startup, not on reloads
- REST API and ADMIN URLs continue to show on every startup for convenience

## Changes Made

### Modified `core/cat/log.py`:
- Added `_get_welcome_flag_path()` method to define flag file location  
- Added `_has_welcome_been_shown()` method to check if welcome was already displayed
- Added `_mark_welcome_as_shown()` method to mark welcome as displayed
- Updated `welcome()` method to conditionally show ASCII art based on flag
- Preserved display of REST API and ADMIN URLs on every startup

### Key Features:
- **Non-intrusive**: Flag file is created in project root and can be safely ignored
- **Developer-friendly**: Removes ASCII art clutter during development reloads
- **Preserves functionality**: Important URLs still shown on every startup
- **Clean implementation**: Uses simple file-based flag system

## Testing
- ✅ First startup shows full welcome message with ASCII cat
- ✅ Subsequent reloads show only REST API and ADMIN URLs  
- ✅ Flag file properly created and detected
- ✅ No breaking changes to existing functionality

## Files Changed
- `core/cat/log.py` - Added flag system and updated welcome method

Closes #1063