### PR TITLE
Update embedder.py

### DIFF
--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -66,7 +66,7 @@ class EmbedderOpenAICompatibleConfig(EmbedderSettings):
             "humanReadableName": "OpenAI-compatible API embedder",
             "description": "Configuration for OpenAI-compatible API embeddings",
             "link": "",
-            "model: ""
+            "model: "",
         }
     )
 

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -58,6 +58,7 @@ class EmbedderDumbConfig(EmbedderSettings):
 class EmbedderOpenAICompatibleConfig(EmbedderSettings):
     oai_comp_api_key: str = None
     url: str
+    model: str
     _pyclass: Type = CustomOpenAIEmbeddings
 
     model_config = ConfigDict(
@@ -65,6 +66,7 @@ class EmbedderOpenAICompatibleConfig(EmbedderSettings):
             "humanReadableName": "OpenAI-compatible API embedder",
             "description": "Configuration for OpenAI-compatible API embeddings",
             "link": "",
+            "model: ""
         }
     )
 

--- a/core/cat/factory/embedder.py
+++ b/core/cat/factory/embedder.py
@@ -66,7 +66,7 @@ class EmbedderOpenAICompatibleConfig(EmbedderSettings):
             "humanReadableName": "OpenAI-compatible API embedder",
             "description": "Configuration for OpenAI-compatible API embeddings",
             "link": "",
-            "model: "",
+            "model": "",
         }
     )
 


### PR DESCRIPTION
The model name was missing

# Description

Model name was missing in the configuration of openai-compatible API of embedding models
