### PR TITLE
Feature request: can avoid storing interactions in episodic memory

### DIFF
--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -653,6 +653,10 @@ Just output the class, nothing else."""
         doc = self.mad_hatter.execute_hook(
             "before_cat_stores_episodic_memory", doc, cat=self
         )
+        match doc:
+            case (None, True):
+                log.info("Document is None; skipping storing in episodic memory.")
+                return
         # store user message in episodic memory
         # TODO: vectorize and store also conversation chunks
         #   (not raw dialog, but summarization)


### PR DESCRIPTION
# Description

## The context

As always, thanks for your work, and the time you may dedicate to my proposal.

Currently, we cannot avoid storing interactions between users and Cat to "episodic memories"

However, we can go around this limitation for our use case with CheshireCat.

## Our workaround

Currently, the method `_store_user_message_in_episodic_memory` does not provide the possibility to avoid storing episodic memories:

```python
 def _store_user_message_in_episodic_memory(self, user_message_text: str):
        doc = Document(
            page_content=user_message_text,
            metadata={"source": self.user_id, "when": time.time()},
        )
        doc = self.mad_hatter.execute_hook(
            "before_cat_stores_episodic_memory", doc, cat=self
        )
        # store user message in episodic memory
        # TODO: vectorize and store also conversation chunks
        #   (not raw dialog, but summarization)
        user_message_embedding = self.embedder.embed_documents([user_message_text])
        _ = self.memory.vectors.episodic.add_point(
            doc.page_content,
            user_message_embedding[0],
            doc.metadata,
        )
```

So, by no, we are using the `before_cat_stores_episodic_memory` hook to overwrite the `Document` attributes with empty ones:
```python
@hook(priority=0)
def before_cat_stores_episodic_memory(doc: Document, cat) -> Document:
    log.warning("Overwriting episodic memory with an empty document.")
    doc = Document(page_content="", metadata={"source": None, "when": None})
    return doc
```

This "trick" works as intended, but leads to some inconvenients.
For instance, we need to run a cron job to periodically clean up the episodic memory.

## Type of change

At first, we thought returning None inside the `before_cat_stores_episodic_memory` hook and adding a check in `_store_user_message_in_episodic_memory` would work.

However, this approach does not work, because of this logic (`/cat/mad_hatter/mad_hatter.py`):
```python
        # run hooks
        for hook in self.hooks[hook_name]:
            try:
                # pass tea_cup to the hooks, along other args
                # hook has at least one argument, and it will be piped
                log.debug(
                    f"Executing {hook.plugin_id}::{hook.name} with priority {hook.priority}"
                )
                tea_spoon = hook.function(
                    deepcopy(tea_cup), *deepcopy(args[1:]), cat=cat
                )
                # log.debug(f"Hook {hook.plugin_id}::{hook.name} returned {tea_spoon}")
                if tea_spoon is not None:
                    tea_cup = tea_spoon
            except Exception:
                log.error(f"Error in plugin {hook.plugin_id}::{hook.name}")
                plugin_obj = self.plugins[hook.plugin_id]
                log.warning(plugin_obj.plugin_specific_error_message())
```

Our proposal is to use "pattern matching" in `/cat/looking_glass/stray_cat.py`, line 656:
if `Document` is a tuple with `None` and `True`, we skip storing it in episodic memory:
```python
    def _store_user_message_in_episodic_memory(self, user_message_text: str):
        doc = Document(
            page_content=user_message_text,
            metadata={"source": self.user_id, "when": time.time()},
        )
        doc = self.mad_hatter.execute_hook(
            "before_cat_stores_episodic_memory", doc, cat=self
        )
        match doc:
            case (None, True):
                log.info("Document is None; skipping storing in episodic memory.")
                return
        # store user message in episodic memory
        # TODO: vectorize and store also conversation chunks
        #   (not raw dialog, but summarization)
        user_message_embedding = self.embedder.embed_documents([user_message_text])
        _ = self.memory.vectors.episodic.add_point(
            doc.page_content,
            user_message_embedding[0],
            doc.metadata,
        )
```

And here is  `before_cat_stores_episodic_memory` hook in our plugin:
```python
@hook(priority=0)
def before_cat_stores_episodic_memory(doc: Document, cat) -> Document:
    log.info("Doc set to None to skip storing episodic memory.")
    return None, True
```

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

