### PR TITLE
Decouple MCP types from Cat chat types

### DIFF
--- a/src/cat/types/__types_adapter.py
+++ b/src/cat/types/__types_adapter.py
@@ -1,0 +1,14 @@
+from mcp.types import Resource
+from mcp.types import TextContent
+from mcp.types import ImageContent
+from mcp.types import AudioContent
+from mcp.types import ResourceLink
+from mcp.types import EmbeddedResource
+
+class AdapterResource(Resource):
+    pass
+
+class AdapterTextContent(TextContent):
+    pass
+
+AdapterContentBlock = TextContent | ImageContent | AudioContent | ResourceLink | EmbeddedResource

--- a/src/cat/types/chats.py
+++ b/src/cat/types/chats.py
@@ -1,7 +1,7 @@
 from typing import List
 from pydantic import BaseModel
 
-from mcp.types import TextContent
+from .text_content import TextContent
 
 from .messages import Message
 from .contexts import Context

--- a/src/cat/types/content_block.py
+++ b/src/cat/types/content_block.py
@@ -1,0 +1,3 @@
+from .__types_adapter import AdapterContentBlock
+
+ContentBlock = AdapterContentBlock

--- a/src/cat/types/contexts.py
+++ b/src/cat/types/contexts.py
@@ -1,13 +1,8 @@
 from typing import List
-from pydantic import BaseModel, field_serializer
-from mcp.types import Resource as MCPResource
+from pydantic import BaseModel
 
 from cat.looking_glass import prompts
-
-class Resource(MCPResource):
-    @field_serializer("uri")
-    def serialize_uri(self, uri):
-        return str(self.uri)
+from .resource import Resource
 
 class Context(BaseModel):
     instructions: str = prompts.MAIN_PROMPT_PREFIX

--- a/src/cat/types/messages.py
+++ b/src/cat/types/messages.py
@@ -9,8 +9,8 @@ from langchain_core.messages import (
     ToolMessage
 )
 
-from mcp.types import ContentBlock, TextContent
-
+from .text_content import TextContent
+from .content_block import ContentBlock
 
 class Message(BaseModel):
     """Single message exchanged between user and assistant, part of a conversation."""

--- a/src/cat/types/resource.py
+++ b/src/cat/types/resource.py
@@ -1,0 +1,8 @@
+from pydantic import field_serializer
+
+from .__types_adapter import AdapterResource
+
+class Resource(AdapterResource):
+    @field_serializer("uri")
+    def serialize_uri(self, uri):
+        return str(self.uri)

--- a/src/cat/types/text_content.py
+++ b/src/cat/types/text_content.py
@@ -1,0 +1,4 @@
+from .__types_adapter import AdapterTextContent
+
+class TextContent(AdapterTextContent):
+    pass


### PR DESCRIPTION
# Description

All Cat types related to the chat are now self-defined within Cat, and all references to MCP types are centralized in `__types_adapter.py`.
This way, if we ever want to detach from the MCP types, we only need to modify the `__types_adapter.py` class.

# Checklist:

- [X] I submitted my PR to branch `develop`
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run or added tests to cover my contribution
