### PR TITLE
[V2] Class based agent tools 

### DIFF
--- a/src/cat/agents/base.py
+++ b/src/cat/agents/base.py
@@ -255,17 +255,25 @@ class Agent(Service, LLMMixin, EventStreamMixin):
 
         for name, func in self.get_agent_tools().items():
             # Create a bound method wrapper that includes self
-            def create_bound_wrapper(bound_func):
+            sig = inspect.signature(func)
+            valid_params = set(sig.parameters.keys()) - {'self'}
+
+            def create_bound_wrapper(bound_func, valid_params):
+
                 async def wrapper(**kwargs):
+                    filtered_kwargs = {
+                        k: v for k, v in kwargs.items()
+                        if k in valid_params
+                    }
                     # Call the bound method (already has self)
-                    return await bound_func(**kwargs) if inspect.iscoroutinefunction(bound_func) else bound_func(
-                        **kwargs)
+                    return await bound_func(**filtered_kwargs) if inspect.iscoroutinefunction(bound_func) else bound_func(
+                        **filtered_kwargs)
 
                 return wrapper
 
             # Bind the function to this instance
             bound_method = func.__get__(self, self.__class__)
-            wrapped_func = create_bound_wrapper(bound_method)
+            wrapped_func = create_bound_wrapper(bound_method, valid_params)
 
             # Create a Tool instance from the decorated function
             tool = Tool.from_decorated_function(

--- a/src/cat/agents/base.py
+++ b/src/cat/agents/base.py
@@ -1,3 +1,5 @@
+import inspect
+from functools import wraps
 from typing import List, Any
 
 from cat.auth.user import User
@@ -7,6 +9,25 @@ from cat.mixin.llm import LLMMixin
 from cat.mixin.stream import EventStreamMixin
 from cat.mad_hatter.decorators import Tool, Service
 #from cat.looking_glass.stray_cat import StrayCat
+
+
+def agent_tool(func=None, *, return_direct=False, examples=None):
+
+    if examples is None:
+        examples = []
+
+    if func is None:
+        return lambda f: agent_tool(f, return_direct=return_direct, examples=examples)
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        return func(self, *args, **kwargs)
+
+    wrapper._is_agent_tool = True
+    wrapper._return_direct = return_direct
+    wrapper._examples = examples
+    return wrapper
+
 
 class Agent(Service, LLMMixin, EventStreamMixin):
 
@@ -128,17 +149,22 @@ class Agent(Service, LLMMixin, EventStreamMixin):
         return prompt_prefix + prompt_suffix
 
     async def list_tools(self) -> List[Tool]:
-        """Get both plugins' tools and MCP tools in Tool format."""
+        """Get plugins' tools, MCP tools, and agent's own tools in CatTool format."""
 
+        # Get MCP tools
         mcp_tools = await self.mcp.list_tools()
         mcp_tools = [
             Tool.from_fastmcp(t, self.mcp.call_tool)
             for t in mcp_tools
         ]
 
+        # Get agent's own tools decorated with @agent_tool
+        agent_tools = self.instantiate_agent_tools()
+
+        # Combine all tools
         tools = await self.execute_hook(
             "agent_allowed_tools",
-            mcp_tools + self.mad_hatter.tools
+            mcp_tools + self.mad_hatter.tools + agent_tools
         )
 
         return tools
@@ -208,8 +234,54 @@ class Agent(Service, LLMMixin, EventStreamMixin):
     def user_id(self) -> str:
         """Get the user ID."""
         return self.user.id
-    
-    
+
+    @classmethod
+    def get_agent_tools(cls):
+        """
+        Get all methods of the class that are decorated with @agent_tool.
+        """
+        agent_tools = {}
+        for name, func in inspect.getmembers(cls):
+            if inspect.isfunction(func) or inspect.ismethod(func):
+                if getattr(func, '_is_agent_tool', False):
+                    agent_tools[name] = func
+        return agent_tools
+
+    def instantiate_agent_tools(self) -> List[Tool]:
+        """
+        Instantiate agent tools as Tool instances.
+        """
+        agent_tools = []
+
+        for name, func in self.get_agent_tools().items():
+            # Create a bound method wrapper that includes self
+            def create_bound_wrapper(bound_func):
+                async def wrapper(**kwargs):
+                    # Call the bound method (already has self)
+                    return await bound_func(**kwargs) if inspect.iscoroutinefunction(bound_func) else bound_func(
+                        **kwargs)
+
+                return wrapper
+
+            # Bind the function to this instance
+            bound_method = func.__get__(self, self.__class__)
+            wrapped_func = create_bound_wrapper(bound_method)
+
+            # Create a Tool instance from the decorated function
+            tool = Tool.from_decorated_function(
+                func,
+                return_direct=getattr(func, '_return_direct', False),
+                examples=getattr(func, '_examples', [])
+            )
+
+            # Replace the func with our bound wrapper so it can be executed properly
+            tool.func = wrapped_func
+
+            agent_tools.append(tool)
+
+        return agent_tools
+
+
     # @property
     # def stream_callback(self):
     #     """Gives access to the stream callback function."""

--- a/src/cat/agents/base.py
+++ b/src/cat/agents/base.py
@@ -1,6 +1,4 @@
-import inspect
-from functools import wraps
-from typing import List, Any
+from typing import List
 
 from cat.auth.user import User
 from cat.looking_glass.cheshire_cat import CheshireCat
@@ -9,24 +7,6 @@ from cat.mixin.llm import LLMMixin
 from cat.mixin.stream import EventStreamMixin
 from cat.mad_hatter.decorators import Tool, Service
 #from cat.looking_glass.stray_cat import StrayCat
-
-
-def agent_tool(func=None, *, return_direct=False, examples=None):
-
-    if examples is None:
-        examples = []
-
-    if func is None:
-        return lambda f: agent_tool(f, return_direct=return_direct, examples=examples)
-
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        return func(self, *args, **kwargs)
-
-    wrapper._is_agent_tool = True
-    wrapper._return_direct = return_direct
-    wrapper._examples = examples
-    return wrapper
 
 
 class Agent(Service, LLMMixin, EventStreamMixin):
@@ -215,6 +195,14 @@ class Agent(Service, LLMMixin, EventStreamMixin):
         agent = self.get_agent(slug)
         return await agent(request)
 
+    def instantiate_agent_tools(self) -> List[Tool]:
+        """Find Tool instances on class and bind them to the agent instance."""
+        return [
+            attr.bind_to(self)
+            for name in dir(self.__class__)
+            if isinstance(attr := getattr(self.__class__, name, None), Tool)
+        ]
+
     @property
     def plugin(self):
         """Access plugin object (used from within a plugin)."""
@@ -234,60 +222,6 @@ class Agent(Service, LLMMixin, EventStreamMixin):
     def user_id(self) -> str:
         """Get the user ID."""
         return self.user.id
-
-    @classmethod
-    def get_agent_tools(cls):
-        """
-        Get all methods of the class that are decorated with @agent_tool.
-        """
-        agent_tools = {}
-        for name, func in inspect.getmembers(cls):
-            if inspect.isfunction(func) or inspect.ismethod(func):
-                if getattr(func, '_is_agent_tool', False):
-                    agent_tools[name] = func
-        return agent_tools
-
-    def instantiate_agent_tools(self) -> List[Tool]:
-        """
-        Instantiate agent tools as Tool instances.
-        """
-        agent_tools = []
-
-        for name, func in self.get_agent_tools().items():
-            # Create a bound method wrapper that includes self
-            sig = inspect.signature(func)
-            valid_params = set(sig.parameters.keys()) - {'self'}
-
-            def create_bound_wrapper(bound_func, valid_params):
-
-                async def wrapper(**kwargs):
-                    filtered_kwargs = {
-                        k: v for k, v in kwargs.items()
-                        if k in valid_params
-                    }
-                    # Call the bound method (already has self)
-                    return await bound_func(**filtered_kwargs) if inspect.iscoroutinefunction(bound_func) else bound_func(
-                        **filtered_kwargs)
-
-                return wrapper
-
-            # Bind the function to this instance
-            bound_method = func.__get__(self, self.__class__)
-            wrapped_func = create_bound_wrapper(bound_method, valid_params)
-
-            # Create a Tool instance from the decorated function
-            tool = Tool.from_decorated_function(
-                func,
-                return_direct=getattr(func, '_return_direct', False),
-                examples=getattr(func, '_examples', [])
-            )
-
-            # Replace the func with our bound wrapper so it can be executed properly
-            tool.func = wrapped_func
-
-            agent_tools.append(tool)
-
-        return agent_tools
 
 
     # @property

--- a/src/cat/mad_hatter/decorators/tool.py
+++ b/src/cat/mad_hatter/decorators/tool.py
@@ -1,3 +1,4 @@
+import inspect
 import time
 from uuid import uuid4
 from dataclasses import asdict
@@ -49,7 +50,7 @@ class Tool:
         
         parsed_function = ParsedFunction.from_function(
             func,
-            exclude_args=["cat"], # awesome, will only be used at execution
+            exclude_args=["cat", "self"], # awesome, will only be used at execution
             validate=False
         )
 
@@ -193,6 +194,39 @@ class Tool:
                 content=tool_output.content.text,
                 raw_event=tool_output.model_dump()
             )
+        )
+
+    def bind_to(self, instance) -> 'Tool':
+        """Bind this tool's function to an instance (for class-based tools)."""
+
+        original_func = self.func
+        sig = inspect.signature(original_func)
+        valid_params = set(sig.parameters.keys()) - {'self'}
+
+        # Bind the method
+        bound_method = original_func.__get__(instance, instance.__class__)
+
+        # Create wrapper
+        def create_bound_wrapper(bound_func, params):
+            async def wrapper(**kwargs):
+                filtered_kwargs = {k: v for k, v in kwargs.items() if k in params}
+                if inspect.iscoroutinefunction(bound_func):
+                    return await bound_func(**filtered_kwargs)
+                else:
+                    return bound_func(**filtered_kwargs)
+
+            return wrapper
+
+        # Return a NEW Tool with the bound function
+        return Tool(
+            func=create_bound_wrapper(bound_method, valid_params),
+            name=self.name,
+            description=self.description,
+            input_schema=self.input_schema,
+            output_schema=self.output_schema,
+            return_direct=self.return_direct,
+            examples=self.examples,
+            is_internal=self.is_internal
         )
 
 


### PR DESCRIPTION
# Description

This PR adds the ability to define tools directly as methods on Agent classes using the `@agent_tool` decorator. Highly inspired by [SuperCatForm's class based tools](https://github.com/lucagobbi/super-cat-form) using Python `__get__` descriptor to bind the tool to the owning instance.

Mentioned #1109 

### Examples

```python
class MyAgent(Agent):
    
    @agent_tool
    async def search(self, query: str) -> str:
        """Search the web for information."""
        # Full access to self.cat, agents state and attributes, etc.
        return await self.some_api.search(query)
    
    @agent_tool(return_direct=True)
    def get_user_name(self) -> str:
        """Get the current user's name."""
        return self.user.name
```

@pieroit couldn't test it deeply 'cause I'm not yet practical with v2, but this could be a starting point.