### PR TITLE
Add community growth roadmap

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -1,0 +1,141 @@
+# Community Growth Roadmap
+
+A practical guide for growing Cheshire Cat's visibility and community. The Cat already has strong fundamentals—great docs, active Discord, clear value prop. This document focuses on amplifying what's working.
+
+## Current Positioning
+
+**Core value**: AI agent as a ready-to-run microservice. One `docker run` command → working conversational agent with RAG, plugins, and admin panel.
+
+**Key differentiators**:
+- API-first architecture (vs. library-first frameworks)
+- Plugin ecosystem with hooks, tools, and conversational forms
+- Built-in RAG with Qdrant
+- Multi-user permissions out of the box
+- 100% containerized deployment
+
+**Target audience**:
+1. Developers wanting conversational AI without infrastructure complexity
+2. Teams building custom assistants/chatbots
+3. Hobbyists exploring AI agents
+
+## Visibility Checklist
+
+### Awesome Lists (not yet listed)
+
+| List | Category | Status |
+|------|----------|--------|
+| [awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) | Frameworks | ⬜ Submit |
+| [awesome-generative-ai](https://github.com/steven2358/awesome-generative-ai) | Agents/Tools | ⬜ Submit |
+| [awesome-ai-tools](https://github.com/mahseema/awesome-ai-tools) | AI Agents | ⬜ Submit |
+| [Awesome-AITools](https://github.com/ikaijua/Awesome-AITools) | Agent Frameworks | ⬜ Submit |
+| [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) | Frameworks | ⬜ Submit |
+
+**Submission template**:
+```markdown
+- [Cheshire Cat](https://github.com/cheshire-cat-ai/core) - AI agent microservice with built-in RAG, plugin system, and admin panel. One docker command to run.
+```
+
+### Already Listed ✅
+- awesome-langchain
+
+## Community Growth
+
+### Content that resonates
+
+Based on the project's strengths:
+
+1. **"Zero to chatbot in 5 minutes"** tutorials
+   - Video: Docker run → chat → first plugin
+   - Blog: Step-by-step with screenshots
+   - Target: Dev.to, Hashnode, YouTube
+
+2. **Plugin showcase**
+   - "10 useful Cheshire Cat plugins"
+   - Highlight community contributions
+   - Cross-post to r/LocalLLaMA, r/selfhosted
+
+3. **Architecture deep-dives**
+   - "How Cheshire Cat handles RAG under the hood"
+   - "Building conversational forms in Python"
+   - Target: Medium, personal blogs, HackerNews
+
+4. **Comparison guides** (honest, not promotional)
+   - "Cheshire Cat vs LangChain: When to use which"
+   - "Self-hosted AI assistants compared"
+
+### Reddit communities
+
+| Subreddit | Fit | Approach |
+|-----------|-----|----------|
+| r/LocalLLaMA | High | Self-hosted angle, show local deployment |
+| r/selfhosted | High | Docker-first, privacy-focused |
+| r/ChatGPT | Medium | Showcase as custom alternative |
+| r/Python | Medium | Technical deep-dives on hooks/plugins |
+| r/MachineLearning | Low | Only for significant releases |
+
+**Reddit posting tips**:
+- Lead with a genuine problem you solved
+- Include a GIF/video of the admin panel
+- Respond to every comment for 2+ hours
+- Don't self-promote—show something useful
+
+### Discord growth
+
+Your Discord is already active. Ideas to amplify:
+
+1. **Plugin of the week** showcase
+2. **Community spotlight**: Feature users building cool things
+3. **Office hours**: Monthly live Q&A with maintainers
+4. **Showcase channel**: Let users share their deployments
+
+## Sustainable Rhythm
+
+### Weekly
+- [ ] Share one community plugin/showcase on Twitter/X
+- [ ] Answer questions on Reddit (r/LocalLLaMA, r/selfhosted)
+- [ ] Engage with AI agent discussions on HackerNews
+
+### Monthly
+- [ ] Publish one tutorial/blog post
+- [ ] Discord community spotlight
+- [ ] Submit to one new awesome-list
+
+### Quarterly
+- [ ] Major feature release with HN/Reddit launch
+- [ ] Update comparison guides
+- [ ] Community survey for roadmap input
+
+## Contributor Community
+
+### Making first contributions easy
+- Tag issues with `good first issue` + difficulty level
+- Create `CONTRIBUTING.md` with local dev setup
+- Welcome bot for first-time contributors
+- Shout-out contributors in release notes
+
+### Plugin ecosystem health
+- Document plugin development thoroughly
+- Create a "plugin template" repo
+- Feature quality plugins in docs
+- Consider a plugin registry/marketplace
+
+## Metrics to Track
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| GitHub stars | ~3k | 5k |
+| Discord members | ? | Track growth |
+| Monthly plugin downloads | ? | Track |
+| Contributors (monthly) | ? | 10+ |
+
+**Tools**: GitHub Insights, Discord analytics, social listening
+
+## Resources
+
+For go-to-market strategies and community building:
+- [Gingiris Open Source Marketing Playbook](https://github.com/Gingiris/opensource-marketing-playbook)
+- [Gingiris Launch Playbook](https://github.com/Gingiris/launch-playbook)
+
+---
+
+*This is a living document. Adapt based on what works for your community.*


### PR DESCRIPTION
Hi! 👋

I put together a practical growth roadmap for Cheshire Cat based on where the project is today.

## What this includes

- **Visibility checklist**: Specific awesome-lists where the Cat is not yet listed (with submission templates)
- **Content ideas**: Tutorials and guides that play to the project's strengths
- **Community rhythm**: Weekly/monthly/quarterly activities
- **Contributor onboarding**: Ideas to grow the plugin ecosystem

## Why I made this

I've been exploring AI agent frameworks, and the Cat's API-first microservice approach is genuinely differentiated. The docs are solid and the Discord is active—this roadmap is about amplifying what's already working.

## Note

This is meant as a starting point, not a prescription. Feel free to modify, cherry-pick ideas, or close if it's not useful. Happy to discuss any part of it.

Thanks for building a great project! 🐱