### PR TITLE
fix: remove debug code that intentionally raises ZeroDivisionError

### DIFF
--- a/core/cat/log.py
+++ b/core/cat/log.py
@@ -172,14 +172,6 @@ class CatLogEngine:
             self.error(c)
             self.critical(c)
 
-        def intentional_error():
-            print(42/0)
-
-        try:
-            intentional_error()
-        except Exception:
-            self.error("This error is just for demonstration purposes.")
-            
 
 # logger instance
 log = CatLogEngine()


### PR DESCRIPTION
Remove the intentional_error() function that was debug code

The function intentionally raises ZeroDivisionError to test error handling,
but should not be in production code.

🤖 Generated with Claude Code