### PR TITLE
feat: add Astraflow provider support (global and China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@
 
 # Set container timezone
 # CCAT_TIMEZONE=Europe/Rome
+
+# Astraflow (by UCloud) — OpenAI-compatible platform supporting 200+ models
+# Sign up (global): https://astraflow.ucloud-global.com
+# ASTRAFLOW_API_KEY=<your_global_api_key>
+
+# Astraflow China endpoint
+# Sign up (China): https://astraflow.ucloud.cn
+# ASTRAFLOW_CN_API_KEY=<your_china_api_key>

--- a/core/cat/factory/llm.py
+++ b/core/cat/factory/llm.py
@@ -300,6 +300,39 @@ class LLMAnthropicChatConfig(LLMSettings):
         }
     )
 
+class LLMAstraflowConfig(LLMSettings):
+    openai_api_key: str
+    model_name: str = "gpt-4o-mini"
+    temperature: float = 0.7
+    streaming: bool = True
+    url: str = "https://api-us-ca.umodelverse.ai/v1"
+    _pyclass: Type = CustomOpenAI
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "humanReadableName": "Astraflow (Global)",
+            "description": "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+            "link": "https://astraflow.ucloud-global.com",
+        }
+    )
+
+
+class LLMAstraflowCNConfig(LLMSettings):
+    openai_api_key: str
+    model_name: str = "gpt-4o-mini"
+    temperature: float = 0.7
+    streaming: bool = True
+    url: str = "https://api.modelverse.cn/v1"
+    _pyclass: Type = CustomOpenAI
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "humanReadableName": "Astraflow (China)",
+            "description": "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint)",
+            "link": "https://astraflow.ucloud.cn",
+        }
+    )
+
 def get_allowed_language_models():
     list_llms_default = [
         LLMOpenAIChatConfig,
@@ -314,6 +347,8 @@ def get_allowed_language_models():
         LLMHuggingFaceTextGenInferenceConfig,
         LLMAnthropicChatConfig,
         LLMCustomConfig,
+        LLMAstraflowConfig,
+        LLMAstraflowCNConfig,
         LLMDefaultConfig,
     ]
 


### PR DESCRIPTION
# Description

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider in `core/cat/factory/llm.py`.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI-compatible, the integration reuses the existing `CustomOpenAI` adapter — no new SDK or subpackage is needed.

Two config classes are added:

| Class | Endpoint | Env var |
|---|---|---|
| `LLMAstraflowConfig` | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `LLMAstraflowCNConfig` | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

### Changes
- `core/cat/factory/llm.py` — two new `LLMSettings` subclasses + entries in `get_allowed_language_models()`
- `.env.example` — documents the two new API key env vars

### Links
- Global: https://astraflow.ucloud-global.com
- China: https://astraflow.ucloud.cn

# Checklist:

- [ ] I submitted my PR to branch `develop`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run or added tests to cover my contribution