### PR TITLE
fix(auth): deny API key auth when no keys configured instead of granting full access

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,10 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-Related to issue #(issue)
-
-## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.  
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project
+- [ ] I submitted my PR to branch `develop`
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have run or added tests to cover my contribution

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ class PizzaForm(CatForm):
 
 ## Roadmap & Contributing
 
+*Attention*: while version 2 is being worked out, we'll only accept bug fixes for v1. Send your PR for v1 on branch `develop`.
+Do not expect to see merged PRs not previously discussed and agreed upon in an issue.
+
 Detailed roadmap is [here](./ROADMAP.md).  
 Send your pull request to the `develop` branch. Here is a [full guide to contributing](./CONTRIBUTING.md).
 

--- a/core/cat/factory/custom_auth_handler.py
+++ b/core/cat/factory/custom_auth_handler.py
@@ -110,11 +110,17 @@ class CoreAuthHandler(BaseAuthHandler):
         ws_key = get_env("CCAT_API_KEY_WS")
 
         if not http_key and not ws_key:
-            return AuthUserInfo(
-                id=user_id,
-                name=user_id,
-                permissions=get_full_permissions()
+            # No API keys are configured — warn once and deny non-JWT access.
+            # Setting CCAT_API_KEY (and optionally CCAT_API_KEY_WS) is required
+            # to protect the server. JWT-based auth continues to work because
+            # is_jwt() routes those credentials through authorize_user_from_jwt()
+            # before this method is ever called.
+            log.warning(
+                "SECURITY WARNING: Neither CCAT_API_KEY nor CCAT_API_KEY_WS is set. "
+                "API key authentication is disabled. Set these environment variables "
+                "to secure your installation."
             )
+            return None
 
         if protocol == "websocket":
             return self._authorize_websocket_key(user_id, api_key, ws_key)

--- a/core/cat/looking_glass/stray_cat.py
+++ b/core/cat/looking_glass/stray_cat.py
@@ -625,7 +625,7 @@ class StrayCat:
 Allowed classes are:
 {labels_list}{examples_list}
 
-"{sentence}" -> """
+Just output the class, nothing else."""
 
         response = self.llm(prompt)
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Cheshire-Cat"
 description = "Production ready AI assistant framework"
-version = "1.9.1"
+version = "1.9.2"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [


### PR DESCRIPTION
## Problem

`CoreAuthHandler.authorize_user_from_key()` has a branch that grants **full admin permissions** to any caller when neither `CCAT_API_KEY` nor `CCAT_API_KEY_WS` is set. The default `compose.yml` and `.env.example` do not set these variables, so a fresh `docker compose up` results in a fully unauthenticated admin API.

Previously noted in #948 (closed without code change).

## Fix

Change the no-key branch to deny access (return `None`) and emit a `SECURITY WARNING` log so operators notice the misconfiguration. JWT-based auth is unaffected — JWTs are routed through `authorize_user_from_jwt()` before this branch is reached.

## Test Plan

- [ ] `GET /users` with no credentials → HTTP 403 (was: 200)
- [ ] `GET /users` with valid `CCAT_API_KEY` → HTTP 200
- [ ] JWT login + bearer token → works normally
- [ ] Log contains `SECURITY WARNING: Neither CCAT_API_KEY...` on startup with no key set

**Note:** Tests using unauthenticated `TestClient` will need `CCAT_API_KEY=test` added to their environment.

## Security Note

CVSS 3.1: `AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` — **Critical (10.0)**. CWE-1188 Insecure Default Initialization.