### PR TITLE
fix: load bundled plugins on Windows

### DIFF
--- a/src/cat/mad_hatter/plugin.py
+++ b/src/cat/mad_hatter/plugin.py
@@ -76,9 +76,12 @@ class Plugin:
         eviction MUST agree on this — otherwise deactivation silently leaves the
         module cached, and a later import returns the stale object (with a
         `__file__` from wherever it was first loaded).
+
+        The path is normalized so Windows separators are handled correctly.
         """
         module_rel_path = os.path.relpath(py_file, config.PLUGINS_PATH)
-        return module_rel_path.replace(".py", "").replace("/", ".")
+        module_rel_path = os.path.normpath(module_rel_path)
+        return os.path.splitext(module_rel_path)[0].replace(os.sep, ".")
 
     def deactivate(self):
         """Deactivate plugin."""


### PR DESCRIPTION
On Windows, `os.path.relpath` returns paths with backslash separators (e.g. `chats\db.py`). The old conversion (`.replace("/", ".")`) only handled forward slashes, producing module names like `chats\db` that `importlib.import_module` cannot resolve.

Replace brittle `.replace(".py", "")` with `os.path.splitext` and use `os.sep` so the platform-native separator is always converted to the dotted notation required by Python's import system.