### PR TITLE
feat: add TwelveLabs video-understanding plugin (Pegasus)

### DIFF
--- a/src/cat/scaffold/plugins/twelvelabs_video/README.md
+++ b/src/cat/scaffold/plugins/twelvelabs_video/README.md
@@ -1,0 +1,47 @@
+# TwelveLabs
+
+A video-understanding agent powered by [TwelveLabs](https://twelvelabs.io)
+**Pegasus**, a video-language model. Give the agent a public video URL and a
+question — it *watches* the footage and answers in natural language: summaries,
+scene descriptions, on-screen text, "what happens when…", and more.
+
+This plugin is **opt-in** and **non-breaking**: it adds one new agent
+(`twelvelabs`) and changes no defaults. The `twelvelabs` SDK is imported lazily
+inside the tool, so the plugin loads even when the dependency isn't installed.
+
+## 1. Install the dependency
+
+```bash
+uv add twelvelabs
+```
+
+## 2. Configure your API key
+
+Grab a free key at [twelvelabs.io](https://twelvelabs.io) — there's a generous
+free tier — and set it in the environment (or your project `.env`):
+
+```bash
+export TWELVELABS_API_KEY=tlk_...
+```
+
+## 3. Ask the agent about a video
+
+Address the agent by its `slug`:
+
+```json
+POST /agents/twelvelabs/message
+{
+  "messages": [
+    { "role": "user", "content": "Summarise https://example.com/clip.mp4" }
+  ]
+}
+```
+
+The agent calls its `analyze_video(video_url, prompt)` tool, which Pegasus
+fetches and analyses server-side. The `video_url` must be publicly reachable.
+
+## Model
+
+| Tool            | Model        | Input             | Output                  |
+| --------------- | ------------ | ----------------- | ----------------------- |
+| `analyze_video` | `pegasus1.5` | Public video URL  | Natural-language answer |

--- a/src/cat/scaffold/plugins/twelvelabs_video/agents/video_agent.py
+++ b/src/cat/scaffold/plugins/twelvelabs_video/agents/video_agent.py
@@ -1,0 +1,84 @@
+"""
+A video-understanding agent powered by TwelveLabs Pegasus.
+
+Pegasus is a video-language model: hand it a video and a question and it
+*watches* the footage to answer — describing scenes, summarising, reading
+on-screen text, spotting moments. This agent exposes that as a single tool,
+`analyze_video`, so the agentic loop can reach for it whenever the user asks
+about a video.
+
+Configuration
+-------------
+Set one environment variable with your TwelveLabs API key (free tier at
+https://twelvelabs.io):
+
+    export TWELVELABS_API_KEY=tlk_...
+
+Then address the agent by its slug:
+
+    POST /agents/twelvelabs/message
+    { "messages": [{ "role": "user",
+        "content": "Summarise https://.../sample.mp4" }] }
+
+The tool takes a **public video URL** (Pegasus fetches it server-side). It is
+opt-in: nothing here changes the default agent or any existing behaviour, and
+the heavy `twelvelabs` dependency is only imported inside the tool, so the
+plugin loads even when the SDK isn't installed.
+"""
+
+import asyncio
+import os
+
+from cat import Agent, tool
+
+
+class TwelveLabsVideoAgent(Agent):
+    slug = "twelvelabs"
+    name = "TwelveLabs Video Agent"
+    description = "Answers questions about videos using TwelveLabs Pegasus."
+
+    system_prompt = (
+        "You are a video analyst. When the user references a video by URL, use "
+        "the `analyze_video` tool to watch it and ground your answer in what the "
+        "tool reports — never guess at a video's contents. Pass the user's "
+        "question through as the prompt so Pegasus answers exactly what was asked."
+    )
+
+    @tool
+    async def analyze_video(self, video_url: str, prompt: str) -> str:
+        """Watch a video at a public URL and answer a question about it.
+
+        Use for any request about the contents of a video: summaries, scene
+        descriptions, on-screen text, "what happens when…", etc.
+
+        Args:
+            video_url: A publicly reachable URL to the video file (mp4, etc.).
+            prompt: The question or instruction about the video, in plain English.
+        """
+
+        api_key = os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            return (
+                "TwelveLabs is not configured. Set the TWELVELABS_API_KEY "
+                "environment variable (free key at https://twelvelabs.io)."
+            )
+
+        # Imported lazily so the plugin loads without the optional SDK installed.
+        from twelvelabs import TwelveLabs
+        from twelvelabs.types.video_context import VideoContext_Url
+
+        def _analyze() -> str:
+            client = TwelveLabs(api_key=api_key)
+            response = client.analyze(
+                model_name="pegasus1.5",
+                video=VideoContext_Url(url=video_url),
+                prompt=prompt,
+                max_tokens=2048,
+            )
+            return response.data or "Pegasus returned no answer for this video."
+
+        try:
+            # The SDK is synchronous; run it off the event loop.
+            return await asyncio.to_thread(_analyze)
+        except Exception as e:
+            return f"TwelveLabs analysis failed: {e}"

--- a/src/cat/scaffold/plugins/twelvelabs_video/plugin.json
+++ b/src/cat/scaffold/plugins/twelvelabs_video/plugin.json
@@ -1,0 +1,12 @@
+{
+    "name": "TwelveLabs",
+    "version": "1.0.0",
+    "description": "A video-understanding agent powered by TwelveLabs Pegasus. Give it a public video URL and a question — it watches the video and answers in natural language.",
+    "author_name": "Mohit Varikuti",
+    "author_url": "https://twelvelabs.io",
+    "plugin_url": "https://github.com/cheshire-cat-ai/core",
+    "tags": "video, multimodal, twelvelabs, pegasus, video understanding",
+    "thumb": "https://raw.githubusercontent.com/twelvelabs-io/twelvelabs-developer-experience/main/assets/twelvelabs.png",
+    "min_cat_version": "2.0.0",
+    "max_cat_version": "Unknown"
+}

--- a/src/cat/scaffold/plugins/twelvelabs_video/requirements.txt
+++ b/src/cat/scaffold/plugins/twelvelabs_video/requirements.txt
@@ -1,0 +1,1 @@
+twelvelabs>=1.2.8

--- a/src/cat/scaffold/plugins/twelvelabs_video/tests/test_twelvelabs.py
+++ b/src/cat/scaffold/plugins/twelvelabs_video/tests/test_twelvelabs.py
@@ -1,0 +1,59 @@
+"""TwelveLabs plugin suite.
+
+Lives in the plugin, so the harness auto-includes it (core + this plugin) for
+every test here. Two no-network tests assert the agent and its tool register
+correctly and that the missing-key path is handled gracefully; one live test
+runs Pegasus end to end and is skipped unless TWELVELABS_API_KEY is set.
+"""
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from cat.ambient.runtime import ccat
+
+
+@pytest_asyncio.fixture(scope="function")
+async def cheshire_cat(async_client):
+    yield ccat()
+
+
+def _analyze_video_tool(agent):
+    """The agent's bound analyze_video tool (its `.func` is the callable)."""
+    return next(
+        t.func for t in agent.instantiate_agent_tools() if t.name == "analyze_video"
+    )
+
+
+async def test_agent_registered_with_tool(cheshire_cat):
+    """The plugin's agent loads by slug and exposes the analyze_video tool."""
+    agent = await cheshire_cat.get("agents", "twelvelabs")
+    assert agent.name == "TwelveLabs Video Agent"
+    tool_names = {t.name for t in agent.instantiate_agent_tools()}
+    assert "analyze_video" in tool_names
+
+
+async def test_missing_key_returns_clear_message(cheshire_cat, monkeypatch):
+    """With no API key set, the tool returns guidance instead of raising."""
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    agent = await cheshire_cat.get("agents", "twelvelabs")
+    analyze = _analyze_video_tool(agent)
+    result = await analyze(video_url="https://example.com/v.mp4", prompt="?")
+    assert "TWELVELABS_API_KEY" in result
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set — skipping live Pegasus call.",
+)
+async def test_analyze_video_live(cheshire_cat):
+    """Live: Pegasus watches a short public sample video and answers."""
+    agent = await cheshire_cat.get("agents", "twelvelabs")
+    analyze = _analyze_video_tool(agent)
+    result = await analyze(
+        video_url="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4",
+        prompt="In one sentence, what happens in this video?",
+    )
+    assert isinstance(result, str) and len(result) > 0
+    assert not result.startswith("TwelveLabs analysis failed")


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds a small **TwelveLabs video-understanding plugin** to the bundled scaffold plugins.

### What it adds
- A new `twelvelabs` agent (`src/cat/scaffold/plugins/twelvelabs_video/`) with one tool, `analyze_video(video_url, prompt)`, that hands a public video URL to TwelveLabs **Pegasus** (`pegasus1.5`) and returns a natural-language answer — summaries, scene descriptions, on-screen text, "what happens when…", etc.
- A per-plugin `requirements.txt` (`twelvelabs>=1.2.8`), a README, and a test suite.

### Why it helps
The Cat is a great place to learn how agents work, and "ask questions about a video" is a capability the core stack doesn't have today. This is a self-contained example of wiring a multimodal model into the agent/tool model, addressable by slug like any other agent.

### Opt-in / non-breaking
It adds exactly one agent and changes no defaults. The `twelvelabs` SDK is imported lazily inside the tool, so the plugin loads fine even when the optional dependency isn't installed, and the tool returns a clear "set TWELVELABS_API_KEY" message instead of raising when unconfigured. (The plugin folder is named `twelvelabs_video` to avoid colliding with the `twelvelabs` SDK package on `sys.path`.)

### How it was tested
`uv run ruff check` is clean on the new files. The plugin suite has three tests run via `uv run pytest`:
- `test_agent_registered_with_tool` — the agent registers by slug and exposes `analyze_video` (no network).
- `test_missing_key_returns_clear_message` — the missing-key path returns guidance, doesn't raise (no network).
- `test_analyze_video_live` — a real Pegasus call against a short public sample video; **skipped unless `TWELVELABS_API_KEY` is set**. Verified passing locally end-to-end (Pegasus returned a correct one-sentence description of the clip).

### A note on process
Per CONTRIBUTING, PRs are expected to follow an assigned issue. I'm opening this directly as a concrete proposal — happy to file/track an issue first or adjust scope if you'd prefer.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
