### PR TITLE
fix(uploads): prevent path traversal in GET /uploads/{path} (CWE-22)

### DIFF
--- a/src/cat/scaffold/plugins/uploads/endpoints.py
+++ b/src/cat/scaffold/plugins/uploads/endpoints.py
@@ -85,9 +85,17 @@ async def get_uploaded_files() -> List[UploadedFileResponse]:
 async def get_uploaded_file(
     path: str = Path(...),
 ) -> FileResponse:
-    full_path = os.path.join(config.UPLOADS_PATH, path)
+    # Resolve the requested path against UPLOADS_PATH and confirm the result
+    # stays inside it. Without this, URL-encoded `..` segments (e.g. `%2e%2e/`,
+    # `..%2f`) survive the router and `os.path.join` happily yields a path
+    # outside the uploads directory, letting an unauthenticated caller fetch
+    # arbitrary readable files (CWE-22).
+    uploads_root = os.path.realpath(config.UPLOADS_PATH)
+    full_path = os.path.realpath(os.path.join(uploads_root, path))
+    if full_path != uploads_root and not full_path.startswith(uploads_root + os.sep):
+        raise HTTPException(status_code=404, detail="File not found")
 
-    if os.path.exists(full_path) and os.path.isfile(full_path):
+    if os.path.isfile(full_path):
         return FileResponse(full_path)
     else:
         raise HTTPException(

--- a/src/cat/scaffold/plugins/uploads/tests/test_path_traversal.py
+++ b/src/cat/scaffold/plugins/uploads/tests/test_path_traversal.py
@@ -1,0 +1,93 @@
+"""Regression test: path traversal must not escape ``UPLOADS_PATH``.
+
+The serving endpoint ``GET /uploads/{path:path}`` joins the URL path parameter
+to ``config.UPLOADS_PATH`` without normalisation or containment. The route is
+unauthenticated (no ``role=`` gate). Raw ``..`` segments are normalised by the
+HTTP client and Starlette, but URL-encoded equivalents (e.g. ``%2e%2e``,
+``..%2f``) pass through to the handler and reach ``FileResponse``, leaking
+files from outside the uploads directory.
+"""
+
+import os
+
+import pytest
+
+from cat import config
+
+
+# Encoded traversal vectors that survive client/Starlette normalisation and
+# previously reached the FileResponse sink.
+_TRAVERSAL_VECTORS = [
+    "%2e%2e/secret.txt",
+    "%2e%2e%2fsecret.txt",
+    "..%2fsecret.txt",
+    ".%2e/secret.txt",
+    "%2e./secret.txt",
+]
+
+
+@pytest.fixture
+def secret_above_uploads():
+    """Plant a secret one directory above ``UPLOADS_PATH`` and clean it up."""
+    os.makedirs(config.UPLOADS_PATH, exist_ok=True)
+    # DATA_PATH is the parent of UPLOADS_PATH in the default layout.
+    secret_path = os.path.join(config.DATA_PATH, "secret.txt")
+    secret = "the-cat-knows-too-much"
+    with open(secret_path, "w") as f:
+        f.write(secret)
+    try:
+        yield secret_path, secret
+    finally:
+        if os.path.exists(secret_path):
+            os.remove(secret_path)
+
+
+@pytest.mark.parametrize("vector", _TRAVERSAL_VECTORS)
+def test_uploads_get_rejects_encoded_path_traversal(
+    anon_client, secret_above_uploads, vector
+):
+    """Encoded ``..`` traversal must not return files outside UPLOADS_PATH."""
+    _, secret = secret_above_uploads
+    response = anon_client.get(f"/uploads/{vector}")
+    assert response.status_code != 200, (
+        f"Path traversal leaked file via {vector!r} "
+        f"(status={response.status_code}, body={response.text!r})"
+    )
+    assert secret not in response.text
+
+
+def test_uploads_get_serves_legitimate_file(anon_client):
+    """A real file inside UPLOADS_PATH must still be served after the fix."""
+    os.makedirs(config.UPLOADS_PATH, exist_ok=True)
+    file_path = os.path.join(config.UPLOADS_PATH, "ok.txt")
+    with open(file_path, "w") as f:
+        f.write("hi")
+    try:
+        response = anon_client.get("/uploads/ok.txt")
+        assert response.status_code == 200
+        assert response.text == "hi"
+    finally:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+
+def test_uploads_get_rejects_absolute_path(anon_client):
+    """An absolute path in the parameter must not escape UPLOADS_PATH either.
+
+    ``os.path.join('/uploads/dir', '/etc/passwd')`` returns ``/etc/passwd`` —
+    a classic pitfall ``os.path.realpath`` containment also closes.
+    """
+    # Plant a known-safe sentinel outside UPLOADS_PATH; check it does not leak.
+    sentinel = os.path.join(config.DATA_PATH, "abs_secret.txt")
+    with open(sentinel, "w") as f:
+        f.write("absolute-secret")
+    try:
+        # ``//`` collapses to ``/`` so Starlette routes this to the parameterised
+        # endpoint with ``path == config.DATA_PATH + "/abs_secret.txt"``.
+        response = anon_client.get(f"/uploads/{sentinel.lstrip('/')}".replace("//", "/"))
+        # Acceptable outcomes: not found, forbidden, or the same path resolved
+        # *inside* UPLOADS_PATH (which won't exist) — never the planted secret.
+        assert "absolute-secret" not in response.text
+    finally:
+        if os.path.exists(sentinel):
+            os.remove(sentinel)


### PR DESCRIPTION
## Summary

`GET /uploads/{path:path}` in `src/cat/scaffold/plugins/uploads/endpoints.py` joins the user-supplied path component directly to `config.UPLOADS_PATH` with `os.path.join` and serves the result with `FileResponse`. There is no normalisation or containment check, and the route has no authentication. An unauthenticated network caller can request URL-encoded `..` segments to read arbitrary files readable by the server process — `data/core/core.db` (which holds API keys), `JWT_SECRET` in config, `/etc/passwd`, etc.

- **CWE-22** — Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)
- **Affected file:** `src/cat/scaffold/plugins/uploads/endpoints.py`, function `get_uploaded_file` (line 85)
- **Severity:** High — unauthenticated arbitrary file read on a default `uv run ccat` install

## Why this is reachable

A small map of the data flow we verified:

1. `@endpoint.get("/uploads/{path:path}", tags=["Uploads"])` is registered with no `role=` kwarg.
2. `EndpointDecorator._wrap` (in `src/cat/mad_hatter/decorators/endpoint.py`) only injects an auth dependency when `role` is non-`None`. With `role` absent, `dependencies=[]` and the route is wrapped in a fresh `Endpoint(APIRouter)` with no router-level dependencies.
3. `cheshire_cat.py` does `self.fastapi_app.include_router(e)` without further dependencies.
4. `RequestContextMiddleware` (in `src/cat/startup.py`) authenticates *best-effort* — its own docstring says "public routes simply get `user = None`" — so an unauthenticated request reaches the handler.
5. Inside the handler, `full_path = os.path.join(config.UPLOADS_PATH, path)` happily produces a path outside the uploads directory when `path` contains URL-encoded `..` segments, and `FileResponse(full_path)` serves it.

The uploads plugin is auto-activated on a fresh install: `scaffolder.py` seeds `active_plugins` from `installed_plugin_names()`, and the uploads plugin ships in `src/cat/scaffold/plugins/uploads/`.

## Proof of Concept

With an unfixed checkout and the default install:

```bash
uv run ccat &   # default bind: 0.0.0.0:1865
# Plant a sentinel outside UPLOADS_PATH (the parent dir, DATA_PATH, is the natural target)
echo 'cat-knows-too-much' > data/secret.txt

# Raw `..` is normalised by curl/Starlette, but URL-encoded forms are not:
curl -s 'http://127.0.0.1:1865/uploads/%2e%2e/secret.txt'   # 200 + leaked content
curl -s 'http://127.0.0.1:1865/uploads/..%2fsecret.txt'      # 200 + leaked content
curl -s 'http://127.0.0.1:1865/uploads/%2e%2e%2fsecret.txt'  # 200 + leaked content
```

Real-world targets readable by the same process include `data/core/core.db` (stores API keys / admin password hashes) and any config file with secrets the process can read.

The included regression test (`src/cat/scaffold/plugins/uploads/tests/test_path_traversal.py`) reproduces this with the project's own `anon_client` fixture and asserts the encoded vectors no longer return 200 after the fix.

## Fix

Resolve both the configured uploads root and the joined candidate path with `os.path.realpath`, then require the candidate to be `==` the root or to start with `root + os.sep`. This closes:

- URL-encoded `..` traversal (`%2e%2e/`, `..%2f`, mixed `.%2e/`, `%2e./`)
- Absolute paths in the parameter — `os.path.join('/uploads', '/etc/passwd')` returns `/etc/passwd`, which the realpath check then rejects
- Symlink-based escapes — `realpath` follows links on both sides, so a symlink inside `UPLOADS_PATH` pointing elsewhere is also rejected

```python
uploads_root = os.path.realpath(config.UPLOADS_PATH)
full_path = os.path.realpath(os.path.join(uploads_root, path))
if full_path != uploads_root and not full_path.startswith(uploads_root + os.sep):
    raise HTTPException(status_code=404, detail="File not found")
```

The fix is intentionally narrow — no signature changes, no new dependencies, no behavioural change for legitimate paths. Returning 404 (rather than 403) matches the existing not-found branch so probes don't learn the layout.

## Test results

- New: `src/cat/scaffold/plugins/uploads/tests/test_path_traversal.py` — 7 cases (5 encoded-traversal vectors + a legitimate-file case + an absolute-path case). All pass.
- Manual verification end-to-end against the live `uv run ccat` server: all three encoded vectors above returned 200 with the planted content before the fix, and return 404 after the fix. The legitimate `GET /uploads/ok.txt` still returns 200.
- The rest of the suite was run; the only failure is a pre-existing, unrelated macOS `/var → /private/var` symlink discrepancy in `tests/utils/test_cat_utils.py` that has nothing to do with this change.

## Scope check (other FileResponse sinks)

`grep` for `FileResponse` shows one other sink in the codebase: `src/cat/scaffold/plugins/ui/endpoints/frontend.py:32`. That handler already does its own `startswith` containment check against its root, so the fix here is correctly scoped to the only vulnerable site — not a cosmetic fix that misses a parallel path.

## Adversarial review

Before opening this PR we tried to disprove the finding. We considered whether (a) Starlette or the HTTP client normalises encoded `..` away before the handler runs, (b) a global auth dependency on `app` or the router mounts the route under a gate, or (c) the uploads plugin is opt-in and so not exposed by default. None of those hold: Starlette decodes `%2e%2e` into `..` only after routing (the path parameter contains the decoded `..` when the handler runs, and `os.path.join` does not normalise it away); `EndpointDecorator` adds no router-level dependencies and `include_router` is called bare; and `installed_plugin_names()` activates the uploads plugin on a fresh install. The middleware authenticates but explicitly does not block on failure. We also checked that the absolute-path pitfall (`os.path.join(root, '/etc/passwd')` returning `/etc/passwd`) is closed by the same `realpath` containment.